### PR TITLE
Fix NewsAPI date range off-by-one and improve sentiment signal quality

### DIFF
--- a/docs/decisions/001-protocol-based-provider-abstractions.md
+++ b/docs/decisions/001-protocol-based-provider-abstractions.md
@@ -1,0 +1,35 @@
+# ADR 001: Protocol-Based Provider Abstractions
+
+**Date:** 2026-02-21
+**Status:** Accepted
+
+## Context
+
+The sentiment analysis pipeline depends on four external services: Yahoo Finance (market data), NewsAPI (news articles), Reddit via PRAW (social posts), and HuggingFace FinBERT (sentiment scoring). 
+
+## Decision
+
+Introduce `typing.Protocol` abstractions for each external dependency:
+
+- `MarketDataProvider` — `get_history(ticker, period) -> DataFrame`
+- `NewsProvider` — `get_articles(ticker, days) -> list[dict]`
+- `SocialProvider` — `get_posts(ticker, days) -> list[dict]`
+- `SentimentModel` — `score(texts) -> list[float]`
+
+Concrete implementations (`YFinanceMarketData`, `NewsAPIProvider`, `RedditProvider`, `FinBERTModel`) live in `qsf.ingestion` and `qsf.nlp`. They are injected into `build_pipeline()` as typed parameters. The module-level `pipeline` instance wires up the production providers in one place (`agents/workflow.py`).
+
+All protocols are decorated with `@runtime_checkable` so `isinstance()` checks work in tests and startup validation.
+
+## Alternatives Considered
+
+**Abstract Base Classes (`ABC`)** — rejected. ABCs imply shared implementation via inheritance, which is inappropriate here; these providers are fully independent. ABCs also require providers to explicitly subclass them, creating unnecessary coupling to the abstraction layer.
+
+**Dependency injection framework** — rejected. The pipeline has exactly four dependencies. A framework would add complexity and a new dependency for no practical gain at this scale.
+
+**Leave hard-coded** — rejected. Made testing require module-level patching (`@patch("qsf.agents.nodes.yf.Ticker")`), which is brittle and ties tests to internal import paths rather than behaviour.
+
+## Consequences
+
+- Swapping a provider means writing one class and changing one argument in `build_pipeline(...)` — nothing else.
+- Tests use direct injection (`build_pipeline(mock_market, mock_news, ...)`) instead of `@patch`, making them independent of internal import structure.
+- No new runtime dependencies — `typing.Protocol` is in the standard library from Python 3.8.

--- a/src/qsf/agents/workflow.py
+++ b/src/qsf/agents/workflow.py
@@ -99,7 +99,9 @@ def build_pipeline(
         )
         if not items:
             return {"error": f"No news or social data found for '{ticker}'"}
+        logger.info("[%s] score_sentiment: calling model.score on %d items", ticker, len(items))
         scores = model.score([item["text"] for item in items])
+        logger.info("[%s] score_sentiment: model.score returned", ticker)
         scored = [
             {**item, "weighted_sentiment": score}
             for item, score in zip(items, scores)

--- a/src/qsf/ingestion/news.py
+++ b/src/qsf/ingestion/news.py
@@ -7,10 +7,19 @@ from datetime import datetime, timedelta
 from newsapi import NewsApiClient
 
 
+def news_from_date(now: datetime, days: int = 28) -> str:
+    """Return the earliest datetime string to pass to NewsAPI for `days` of history.
+
+    Defaults to 28 days to stay safely within the NewsAPI free plan's 30-day
+    exclusive rolling window.
+    """
+    return (now - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%S")
+
+
 class NewsAPIProvider:
-    def get_articles(self, ticker: str, days: int = 30) -> list[dict]:
+    def get_articles(self, ticker: str, days: int = 28) -> list[dict]:
         client = NewsApiClient(api_key=os.getenv("NEWS_API_KEY"))
-        from_date = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+        from_date = news_from_date(datetime.now(), days)
         response = client.get_everything(
             q=ticker,
             from_param=from_date,
@@ -19,7 +28,24 @@ class NewsAPIProvider:
             page_size=100,
         )
         return [
-            {"text": a["title"], "date": a["publishedAt"][:10], "source": "news"}
+            {
+                "text": _article_text(a),
+                "date": a["publishedAt"][:10],
+                "source": "news",
+            }
             for a in response.get("articles", [])
             if a.get("title")
         ]
+
+
+def _article_text(article: dict) -> str:
+    """Combine headline and description for richer FinBERT input.
+
+    NewsAPI free plan does not provide full article body, so we concatenate
+    the title and description to give the model more context than a headline alone.
+    """
+    title = article.get("title", "")
+    description = article.get("description") or ""
+    if description:
+        return f"{title}. {description}"
+    return title

--- a/src/qsf/nlp/sentiment.py
+++ b/src/qsf/nlp/sentiment.py
@@ -3,6 +3,7 @@ HuggingFace FinBERT sentiment model.
 """
 import logging
 import os
+import time
 
 import requests
 
@@ -10,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 FINBERT_URL = "https://router.huggingface.co/hf-inference/models/ProsusAI/finbert"
 SENTIMENT_MAP = {"positive": 1, "negative": -1, "neutral": 0}
+HF_REQUEST_TIMEOUT = 10  # seconds — applies to health check and per-item scoring requests
 
 
 class FinBERTModel:
@@ -23,9 +25,21 @@ class FinBERTModel:
         scores = []
         failed = 0
 
+        logger.info("FinBERTModel.score: scoring %d items via HuggingFace API (1 request per item)", len(texts))
+        if not texts:
+            return scores
+        try:
+            t0 = time.monotonic()
+            probe = requests.post(FINBERT_URL, headers=headers, json={"inputs": "test"}, timeout=HF_REQUEST_TIMEOUT)
+            elapsed = time.monotonic() - t0
+            logger.info("FinBERTModel.score: HuggingFace health check — HTTP %d in %.2fs", probe.status_code, elapsed)
+        except Exception as e:
+            logger.warning("FinBERTModel.score: HuggingFace health check failed — %s: %s", type(e).__name__, e)
         for idx, text in enumerate(texts):
+            if idx % 10 == 0:
+                logger.info("FinBERTModel.score: progress %d/%d", idx, len(texts))
             try:
-                response = requests.post(FINBERT_URL, headers=headers, json={"inputs": text})
+                response = requests.post(FINBERT_URL, headers=headers, json={"inputs": text}, timeout=HF_REQUEST_TIMEOUT)
                 response.raise_for_status()
                 result = response.json()
                 if not isinstance(result, list) or not result:
@@ -38,7 +52,12 @@ class FinBERTModel:
                 # Single-text requests return [[{label_dicts}]] — unwrap the outer list
                 label_scores = result[0] if isinstance(result[0], list) else result
                 top = max(label_scores, key=lambda x: x["score"])
-                scores.append(SENTIMENT_MAP.get(top["label"].lower(), 0) * top["score"])
+                score = SENTIMENT_MAP.get(top["label"].lower(), 0) * top["score"]
+                logger.info(
+                    "FinBERTModel.score: item %d/%d — %s (%.3f)",
+                    idx + 1, len(texts), top["label"].lower(), score,
+                )
+                scores.append(score)
             except requests.HTTPError as e:
                 logger.warning(
                     "FinBERTModel.score: item %d/%d failed — HTTP %s: %s",

--- a/tests/unit/test_ingestion.py
+++ b/tests/unit/test_ingestion.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from qsf.ingestion.market import YFinanceMarketData
-from qsf.ingestion.news import NewsAPIProvider
+from qsf.ingestion.news import NewsAPIProvider, news_from_date, _article_text
 from qsf.ingestion.social import RedditProvider
 
 
@@ -47,6 +47,44 @@ class TestYFinanceMarketData:
 
 
 # ---------------------------------------------------------------------------
+# news_from_date()
+# ---------------------------------------------------------------------------
+
+class TestNewsFromDate:
+    def test_28_day_window_stays_within_api_limit(self):
+        # NewsAPI free plan has a 30-day exclusive rolling window.
+        # We request 28 days to stay safely within that limit.
+        # 29 and 30 days were tried but both failed in practice — the API server
+        # clock differs from local time, so the boundary can shift by a day
+        # depending on when the request is made. 28 days gives enough buffer.
+        now = datetime(2026, 3, 1, 14, 30, 0)
+        result = news_from_date(now, days=28)
+        assert result == "2026-02-01T14:30:00"
+
+
+# ---------------------------------------------------------------------------
+# _article_text()
+# ---------------------------------------------------------------------------
+
+class TestArticleText:
+    def test_combines_title_and_description(self):
+        article = {"title": "IonQ beats earnings", "description": "Strong Q4 results."}
+        assert _article_text(article) == "IonQ beats earnings. Strong Q4 results."
+
+    def test_falls_back_to_title_when_description_is_none(self):
+        article = {"title": "IonQ beats earnings", "description": None}
+        assert _article_text(article) == "IonQ beats earnings"
+
+    def test_falls_back_to_title_when_description_is_missing(self):
+        article = {"title": "IonQ beats earnings"}
+        assert _article_text(article) == "IonQ beats earnings"
+
+    def test_falls_back_to_title_when_description_is_empty_string(self):
+        article = {"title": "IonQ beats earnings", "description": ""}
+        assert _article_text(article) == "IonQ beats earnings"
+
+
+# ---------------------------------------------------------------------------
 # NewsAPIProvider.get_articles()
 # ---------------------------------------------------------------------------
 
@@ -55,13 +93,13 @@ class TestNewsAPIProvider:
     def test_returns_correctly_shaped_items(self, mock_client_class):
         mock_client_class.return_value.get_everything.return_value = {
             "articles": [
-                {"title": "IonQ beats earnings", "publishedAt": "2026-02-10T10:00:00Z"},
-                {"title": "Quantum stocks rise", "publishedAt": "2026-02-11T14:00:00Z"},
+                {"title": "IonQ beats earnings", "description": "Strong Q4 results.", "publishedAt": "2026-02-10T10:00:00Z"},
+                {"title": "Quantum stocks rise", "description": None, "publishedAt": "2026-02-11T14:00:00Z"},
             ]
         }
         items = NewsAPIProvider().get_articles("IONQ")
         assert len(items) == 2
-        assert items[0]["text"] == "IonQ beats earnings"
+        assert items[0]["text"] == "IonQ beats earnings. Strong Q4 results."
         assert items[0]["date"] == "2026-02-10"
         assert items[0]["source"] == "news"
 
@@ -69,8 +107,8 @@ class TestNewsAPIProvider:
     def test_skips_articles_with_no_title(self, mock_client_class):
         mock_client_class.return_value.get_everything.return_value = {
             "articles": [
-                {"title": None, "publishedAt": "2026-02-10T10:00:00Z"},
-                {"title": "Valid article", "publishedAt": "2026-02-10T10:00:00Z"},
+                {"title": None, "description": "Some description.", "publishedAt": "2026-02-10T10:00:00Z"},
+                {"title": "Valid article", "description": None, "publishedAt": "2026-02-10T10:00:00Z"},
             ]
         }
         items = NewsAPIProvider().get_articles("IONQ")

--- a/tests/unit/test_sentiment_logic.py
+++ b/tests/unit/test_sentiment_logic.py
@@ -93,7 +93,7 @@ class TestFinBERTModel:
         """
         mock_post.return_value.json.return_value = [self._make_hf_response("positive", 0.9)]
         scores = FinBERTModel().score(["text"] * 5)
-        assert mock_post.call_count == 5
+        assert mock_post.call_count == 6  # 1 health check + 5 item requests
         assert len(scores) == 5
 
     @patch("qsf.nlp.sentiment.requests.post")
@@ -108,9 +108,9 @@ class TestFinBERTModel:
         mock_response.text = "Rate limit exceeded"
         bad.raise_for_status.side_effect = requests.HTTPError(response=mock_response)
 
-        mock_post.side_effect = [good, bad, good]
+        mock_post.side_effect = [good, good, bad, good]  # health check + 3 item requests
         scores = FinBERTModel().score(["text1", "text2", "text3"])
-        assert mock_post.call_count == 3
+        assert mock_post.call_count == 4  # 1 health check + 3 item requests
         assert len(scores) == 2
 
     @patch("qsf.nlp.sentiment.requests.post")


### PR DESCRIPTION
## Summary

- Fixes NewsAPI date range off-by-one bug — 30 days lands 31 days ago, and 29 days lands exactly on the exclusive boundary (also rejected due to API server clock differences). Extracted `news_from_date()` with a 28-day default as a safe buffer.
- Concatenates article title + description to give FinBERT richer input than headlines alone, reducing neutral bias
- Adds HuggingFace health check, per-item progress/result logging, and a single `HF_REQUEST_TIMEOUT` constant covering all HF requests

## Test plan

- [ ] `TestNewsFromDate` — verifies 28-day window stays within API limit
- [ ] `TestArticleText` — covers title+description, title-only fallback (None, missing, empty string)
- [ ] Updated `TestNewsAPIProvider` — reflects new `text` field format
- [ ] Updated `TestFinBERTModel` — accounts for health check probe call in call counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)