### PR TITLE
Improve search query precision with company name lookup and expanded subreddits

### DIFF
--- a/docs/decisions/005-company-name-search-query.md
+++ b/docs/decisions/005-company-name-search-query.md
@@ -1,0 +1,54 @@
+# ADR 005: Use Company Name for Search Queries Instead of Raw Ticker Symbol
+
+**Date:** 2026-03-03
+**Status:** Accepted
+
+## Context
+
+Search queries using the raw ticker symbol produced poor results for tickers that share their name with common English words. For example, searching `FORM` (FormFactor Inc.) returned articles and Reddit posts containing the word "form" in any context — chemistry papers, tax guides, movie reviews, squirrel behaviour articles — none related to the stock. The same problem applies to any ticker that is also a real word: `OPEN`, `WORK`, `RIDE`, `HOOD`, etc.
+
+The `$TICKER` cashtag convention was considered as a fix. It works on social platforms (Reddit, Twitter/X) where cashtags are a deliberate tagging system, but NewsAPI treats `$` as punctuation and strips it, making `$FORM` identical to `FORM`.
+
+## Decision
+
+Fetch the company's legal name from yfinance (already a dependency for market data) and strip legal suffixes to produce a search-friendly brand name:
+
+```python
+def company_search_name(full_name: str) -> str:
+    name = full_name.split(",")[0]
+    name = re.sub(r'\s+(Inc\.?|Corp\.?|Corporation|Ltd\.?|LLC|Co\.)$', '', name, flags=re.IGNORECASE)
+    return name.strip()
+```
+
+This runs once per pipeline invocation in `_fetch_market_data` via `market.get_company_name(ticker)` and is stored in pipeline state.
+
+The two providers use different query strategies because they have different search semantics:
+
+- **NewsAPI**: `q='"FormFactor"'` — quoted exact phrase only. Cashtags are not supported; adding `OR "$FORM"` would reintroduce the noise problem since `$` is stripped.
+- **Reddit**: `query='"FormFactor" OR "$FORM"'` — company name plus cashtag fallback, since Reddit natively understands cashtag notation.
+
+## Alternatives Considered
+
+**Raw ticker as search query** — rejected. Produces irrelevant results for any ticker that is a common English word. 100 articles returned for `FORM`, none about FormFactor.
+
+**`$TICKER` cashtag only** — rejected for NewsAPI (cashtag stripped, no improvement). Kept for Reddit as a fallback alongside company name.
+
+**Quoted ticker (`"FORM"`)** — rejected. Still matches any article quoting the word "form", just with slightly fewer false positives. Does not help with body-text matches.
+
+**External ticker→company API (Alpha Vantage, FMP, etc.)** — rejected. Adds a new dependency and API key. yfinance already provides `longName` and `shortName` via `.info` with no additional cost or dependency.
+
+## Consequences
+
+**Improvements:**
+- Unambiguous tickers (`IONQ`, `TSLA`, `NVDA`) are unaffected — their names don't appear in everyday prose.
+- For ambiguous tickers, relevant articles surface that were previously buried under noise. For `FORM`, the two actual FormFactor news articles (earnings beat, price target raise) now appear in results.
+
+**Known Limitations:**
+
+1. **Company name doubles as a common term.** `FormFactor` is also the industry term for the physical size/shape of hardware. Searches still return camera reviews, NAS reviews, and phone articles that use "form factor" as a noun. There is no keyword-only solution to this disambiguation.
+
+2. **Paywalled article descriptions.** NewsAPI free plan does not provide full article body. For wire service articles (Seeking Alpha, TD Cowen research), the description is often `"See the rest of the story"`. FinBERT receives only the headline and that stub, which is insufficient context to score confidently — these articles score neutral (0.000) even when the headline clearly signals positive or negative sentiment (e.g. "FormFactor price target raised by $30", "FormFactor reports Q4 EPS beat").
+
+3. **Low-coverage tickers.** Small-cap stocks like `FORM` are rarely discussed on Reddit. Even with the correct search query, Reddit returns general investing posts that happen to mention "form factor" or include the text `$FORM` incidentally. The social sentiment signal for low-coverage tickers is noise, not signal.
+
+4. **yfinance `.info` latency.** `get_company_name()` makes a separate yfinance API call on each pipeline invocation. For well-known tickers this is fast (~100ms), but adds latency for the first cold request.

--- a/src/qsf/agents/workflow.py
+++ b/src/qsf/agents/workflow.py
@@ -13,7 +13,7 @@ import pandas as pd
 from langgraph.graph import END, StateGraph
 
 from qsf.common.providers import MarketDataProvider, NewsProvider, SentimentModel, SocialProvider
-from qsf.common.utils import safe
+from qsf.common.utils import safe, company_search_name
 from qsf.ingestion import YFinanceMarketData, NewsAPIProvider, RedditProvider
 from qsf.nlp import FinBERTModel
 
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class PipelineState(TypedDict, total=False):
     ticker: str
+    company_name: str
     stock_df: Any
     news_items: list
     reddit_items: list
@@ -51,13 +52,17 @@ def build_pipeline(
                 "[%s] fetch_market_data: only %d trading days returned, expected ~21",
                 ticker, days,
             )
-        return {"stock_df": stock_df}
+        raw_name = market.get_company_name(ticker)
+        company_name = company_search_name(raw_name)
+        logger.info("[%s] fetch_market_data: company name resolved to '%s'", ticker, company_name)
+        return {"stock_df": stock_df, "company_name": company_name}
 
     def _fetch_news(state: dict) -> dict:
         if state.get("error"):
             return {}
         ticker = state["ticker"]
-        news_items = news.get_articles(ticker)
+        company_name = state.get("company_name", "")
+        news_items = news.get_articles(ticker, company_name)
         count = len(news_items)
         logger.info("[%s] fetch_news: %d articles returned", ticker, count)
         if count == 0:
@@ -76,7 +81,8 @@ def build_pipeline(
         if state.get("error"):
             return {}
         ticker = state["ticker"]
-        reddit_items = social.get_posts(ticker)
+        company_name = state.get("company_name", "")
+        reddit_items = social.get_posts(ticker, company_name)
         count = len(reddit_items)
         logger.info("[%s] fetch_reddit: %d posts returned", ticker, count)
         for item in reddit_items:

--- a/src/qsf/common/providers.py
+++ b/src/qsf/common/providers.py
@@ -12,17 +12,18 @@ import pandas as pd
 @runtime_checkable
 class MarketDataProvider(Protocol):
     def get_history(self, ticker: str, period: str) -> pd.DataFrame: ...
+    def get_company_name(self, ticker: str) -> str: ...
 
 
 @runtime_checkable
 class NewsProvider(Protocol):
-    def get_articles(self, ticker: str, days: int) -> list[dict]: ...
+    def get_articles(self, ticker: str, company_name: str = "", days: int = 28) -> list[dict]: ...
     # each dict: {"text": str, "date": "YYYY-MM-DD", "source": "news"}
 
 
 @runtime_checkable
 class SocialProvider(Protocol):
-    def get_posts(self, ticker: str, days: int) -> list[dict]: ...
+    def get_posts(self, ticker: str, company_name: str = "", days: int = 30) -> list[dict]: ...
     # each dict: {"text": str, "date": "YYYY-MM-DD", "source": "social"}
 
 

--- a/src/qsf/common/utils.py
+++ b/src/qsf/common/utils.py
@@ -2,6 +2,7 @@
 Shared utility functions.
 """
 import math
+import re
 from typing import Any
 
 
@@ -11,3 +12,22 @@ def safe(val: Any, decimals: int = 4) -> float | None:
         return None
     f = float(val)
     return None if (math.isnan(f) or math.isinf(f)) else round(f, decimals)
+
+
+def company_search_name(full_name: str) -> str:
+    """Extract a search-friendly company name from a legal name.
+
+    Strips legal suffixes so searches use the brand name people actually write
+    in articles and social posts rather than the full registered name.
+
+    Examples:
+        "FormFactor, Inc."   -> "FormFactor"
+        "Tesla, Inc."        -> "Tesla"
+        "NVIDIA Corporation" -> "NVIDIA"
+        "Alphabet Inc."      -> "Alphabet"
+    """
+    if not full_name:
+        return ""
+    name = full_name.split(",")[0]
+    name = re.sub(r'\s+(Inc\.?|Corp\.?|Corporation|Ltd\.?|LLC|Co\.)$', '', name, flags=re.IGNORECASE)
+    return name.strip()

--- a/src/qsf/ingestion/market.py
+++ b/src/qsf/ingestion/market.py
@@ -8,3 +8,7 @@ import yfinance as yf
 class YFinanceMarketData:
     def get_history(self, ticker: str, period: str) -> pd.DataFrame:
         return yf.Ticker(ticker).history(period=period)
+
+    def get_company_name(self, ticker: str) -> str:
+        info = yf.Ticker(ticker).info
+        return info.get("longName") or info.get("shortName") or ""

--- a/src/qsf/ingestion/news.py
+++ b/src/qsf/ingestion/news.py
@@ -17,11 +17,12 @@ def news_from_date(now: datetime, days: int = 28) -> str:
 
 
 class NewsAPIProvider:
-    def get_articles(self, ticker: str, days: int = 28) -> list[dict]:
+    def get_articles(self, ticker: str, company_name: str = "", days: int = 28) -> list[dict]:
         client = NewsApiClient(api_key=os.getenv("NEWS_API_KEY"))
         from_date = news_from_date(datetime.now(), days)
+        query = f'"{company_name}"' if company_name else ticker
         response = client.get_everything(
-            q=ticker,
+            q=query,
             from_param=from_date,
             language="en",
             sort_by="publishedAt",

--- a/src/qsf/ingestion/social.py
+++ b/src/qsf/ingestion/social.py
@@ -9,7 +9,7 @@ import praw
 
 logger = logging.getLogger(__name__)
 
-REDDIT_SUBREDDITS = ["stocks", "investing", "wallstreetbets"]
+REDDIT_SUBREDDITS = ["stocks", "investing", "wallstreetbets", "Superstonk", "StockMarket", "QuantumComputing"]
 REDDIT_MAX_COMMENTS = 5       # top N comments by upvotes to include per post
 REDDIT_MAX_CHARS = 1800       # ~450 BERT tokens — hard cap on combined text per post
 
@@ -56,17 +56,18 @@ def _post_text(post) -> str:
 
 
 class RedditProvider:
-    def get_posts(self, ticker: str, days: int = 30) -> list[dict]:
+    def get_posts(self, ticker: str, company_name: str = "", days: int = 30) -> list[dict]:
         reddit = praw.Reddit(
             client_id=os.getenv("REDDIT_CLIENT_ID"),
             client_secret=os.getenv("REDDIT_CLIENT_SECRET"),
             user_agent=os.getenv("REDDIT_USER_AGENT", "qsent/0.1"),
         )
+        query = f'"{company_name}" OR "${ticker}"' if company_name else f"${ticker}"
         cutoff = datetime.now() - timedelta(days=days)
         posts = []
         for subreddit in REDDIT_SUBREDDITS:
             for post in reddit.subreddit(subreddit).search(
-                ticker, sort="new", time_filter="month", limit=50
+                query, sort="new", time_filter="month", limit=50
             ):
                 created = datetime.fromtimestamp(post.created_utc)
                 if created >= cutoff:

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -28,6 +28,7 @@ MOCK_SCORES = [0.8, 0.6, 0.7]
 def make_pipeline(history=None, articles=None, posts=None, scores=None):
     market = MagicMock()
     market.get_history.return_value = MOCK_HIST if history is None else history
+    market.get_company_name.return_value = "IonQ, Inc."
 
     news = MagicMock()
     news.get_articles.return_value = MOCK_NEWS if articles is None else articles
@@ -74,5 +75,5 @@ def test_ticker_is_available_throughout_pipeline():
     state = pipeline.invoke({"ticker": "IONQ"})
 
     assert state["ticker"] == "IONQ"
-    mock_news.get_articles.assert_called_once_with("IONQ")
-    mock_social.get_posts.assert_called_once_with("IONQ")
+    mock_news.get_articles.assert_called_once_with("IONQ", "IonQ")
+    mock_social.get_posts.assert_called_once_with("IONQ", "IonQ")

--- a/tests/unit/test_ingestion.py
+++ b/tests/unit/test_ingestion.py
@@ -47,6 +47,30 @@ class TestYFinanceMarketData:
 
 
 # ---------------------------------------------------------------------------
+# YFinanceMarketData.get_company_name()
+# ---------------------------------------------------------------------------
+
+class TestYFinanceGetCompanyName:
+    @patch("qsf.ingestion.market.yf.Ticker")
+    def test_returns_long_name(self, mock_ticker):
+        mock_ticker.return_value.info = {"longName": "FormFactor, Inc.", "shortName": "FormFactor Inc."}
+        result = YFinanceMarketData().get_company_name("FORM")
+        assert result == "FormFactor, Inc."
+
+    @patch("qsf.ingestion.market.yf.Ticker")
+    def test_falls_back_to_short_name(self, mock_ticker):
+        mock_ticker.return_value.info = {"longName": None, "shortName": "FormFactor Inc."}
+        result = YFinanceMarketData().get_company_name("FORM")
+        assert result == "FormFactor Inc."
+
+    @patch("qsf.ingestion.market.yf.Ticker")
+    def test_returns_empty_string_when_no_name(self, mock_ticker):
+        mock_ticker.return_value.info = {}
+        result = YFinanceMarketData().get_company_name("FAKE")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
 # news_from_date()
 # ---------------------------------------------------------------------------
 
@@ -120,6 +144,20 @@ class TestNewsAPIProvider:
         mock_client_class.return_value.get_everything.return_value = {"articles": []}
         items = NewsAPIProvider().get_articles("IONQ")
         assert items == []
+
+    @patch("qsf.ingestion.news.NewsApiClient")
+    def test_searches_with_ticker_when_no_company_name(self, mock_client_class):
+        mock_client_class.return_value.get_everything.return_value = {"articles": []}
+        NewsAPIProvider().get_articles("FORM")
+        call_kwargs = mock_client_class.return_value.get_everything.call_args.kwargs
+        assert call_kwargs["q"] == "FORM"
+
+    @patch("qsf.ingestion.news.NewsApiClient")
+    def test_searches_with_quoted_company_name(self, mock_client_class):
+        mock_client_class.return_value.get_everything.return_value = {"articles": []}
+        NewsAPIProvider().get_articles("FORM", company_name="FormFactor")
+        call_kwargs = mock_client_class.return_value.get_everything.call_args.kwargs
+        assert call_kwargs["q"] == '"FormFactor"'
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +244,7 @@ class TestRedditProvider:
             self._make_post("Quantum computing outlook", days_ago=10),
         ]
         items = RedditProvider().get_posts("IONQ")
-        assert len(items) == 6  # 2 posts × 3 subreddits
+        assert len(items) == 12  # 2 posts × 6 subreddits
         assert items[0]["source"] == "social"
         assert items[0]["text"] == "IONQ hits new high"
 
@@ -225,12 +263,26 @@ class TestRedditProvider:
             self._make_post("IONQ post", days_ago=3),
         ]
         RedditProvider().get_posts("IONQ")
-        assert mock_reddit_class.return_value.subreddit.call_count == 3
+        assert mock_reddit_class.return_value.subreddit.call_count == 6
 
     @patch("qsf.ingestion.social.praw.Reddit")
     def test_calls_replace_more_on_each_post(self, mock_reddit_class):
         post = self._make_post("IONQ post", days_ago=3)
         mock_reddit_class.return_value.subreddit.return_value.search.return_value = [post]
         RedditProvider().get_posts("IONQ")
-        # replace_more called once per post per subreddit (3 subreddits)
-        assert post.comments.replace_more.call_count == 3
+        # replace_more called once per post per subreddit (6 subreddits)
+        assert post.comments.replace_more.call_count == 6
+
+    @patch("qsf.ingestion.social.praw.Reddit")
+    def test_searches_with_cashtag_when_no_company_name(self, mock_reddit_class):
+        mock_subreddit = mock_reddit_class.return_value.subreddit.return_value
+        mock_subreddit.search.return_value = []
+        RedditProvider().get_posts("FORM")
+        mock_subreddit.search.assert_called_with("$FORM", sort="new", time_filter="month", limit=50)
+
+    @patch("qsf.ingestion.social.praw.Reddit")
+    def test_searches_with_company_name_and_cashtag(self, mock_reddit_class):
+        mock_subreddit = mock_reddit_class.return_value.subreddit.return_value
+        mock_subreddit.search.return_value = []
+        RedditProvider().get_posts("FORM", company_name="FormFactor")
+        mock_subreddit.search.assert_called_with('"FormFactor" OR "$FORM"', sort="new", time_filter="month", limit=50)

--- a/tests/unit/test_nodes.py
+++ b/tests/unit/test_nodes.py
@@ -37,6 +37,7 @@ def make_providers(
     """Return four mock providers with default happy-path return values."""
     market = MagicMock()
     market.get_history.return_value = MOCK_HIST if history is None else history
+    market.get_company_name.return_value = "IonQ, Inc."
 
     news = MagicMock()
     news.get_articles.return_value = MOCK_NEWS if articles is None else articles
@@ -111,7 +112,7 @@ class TestFetchNews:
         market, news, social, model = make_providers()
         pipeline = build_pipeline(market, news, social, model)
         pipeline.invoke({"ticker": "IONQ"})
-        news.get_articles.assert_called_once_with("IONQ")
+        news.get_articles.assert_called_once_with("IONQ", "IonQ")
 
     def test_skips_on_upstream_error(self):
         market, news, social, model = make_providers(history=pd.DataFrame())
@@ -135,7 +136,7 @@ class TestFetchReddit:
         market, news, social, model = make_providers()
         pipeline = build_pipeline(market, news, social, model)
         pipeline.invoke({"ticker": "IONQ"})
-        social.get_posts.assert_called_once_with("IONQ")
+        social.get_posts.assert_called_once_with("IONQ", "IonQ")
 
     def test_skips_on_upstream_error(self):
         market, news, social, model = make_providers(history=pd.DataFrame())

--- a/tests/unit/test_sentiment_logic.py
+++ b/tests/unit/test_sentiment_logic.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from qsf.common.utils import safe
+from qsf.common.utils import safe, company_search_name
 from qsf.nlp.sentiment import FinBERTModel, SENTIMENT_MAP
 
 
@@ -42,6 +42,36 @@ class TestSafe:
 
     def test_negative(self):
         assert safe(-0.75) == -0.75
+
+
+# ---------------------------------------------------------------------------
+# company_search_name() - legal name → brand name
+# ---------------------------------------------------------------------------
+
+class TestCompanySearchName:
+    def test_strips_inc_after_comma(self):
+        assert company_search_name("FormFactor, Inc.") == "FormFactor"
+
+    def test_strips_inc_after_comma_tesla(self):
+        assert company_search_name("Tesla, Inc.") == "Tesla"
+
+    def test_strips_corporation_suffix(self):
+        assert company_search_name("NVIDIA Corporation") == "NVIDIA"
+
+    def test_strips_inc_without_comma(self):
+        assert company_search_name("Alphabet Inc.") == "Alphabet"
+
+    def test_strips_ltd(self):
+        assert company_search_name("Some Company Ltd.") == "Some Company"
+
+    def test_strips_llc(self):
+        assert company_search_name("Some Company LLC") == "Some Company"
+
+    def test_no_suffix_returned_as_is(self):
+        assert company_search_name("Apple") == "Apple"
+
+    def test_empty_string_returns_empty(self):
+        assert company_search_name("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fetches company legal name from yfinance (`get_company_name()`) and strips legal suffixes (`company_search_name()`) to produce a search-friendly brand name (e.g. `"FormFactor, Inc."` → `"FormFactor"`)
- NewsAPI now searches with quoted company name (`q='"FormFactor"'`) instead of raw ticker, eliminating noise from ambiguous tickers like `FORM`
- Reddit now searches with company name + cashtag fallback (`"FormFactor" OR "$FORM"`) for better coverage across both conventions
- Expanded Reddit subreddits from 3 → 6: added `Superstonk`, `StockMarket`, `QuantumComputing` for better niche ticker coverage
- `company_name` stored in `PipelineState` and passed through to both providers per pipeline run
- Added ADR 005 documenting the decision, rationale, and known limitations (paywalled articles, low-coverage tickers, "form factor" as hardware term)

## Test plan

- [ ] Run `uv run pytest tests/unit/` — 74 tests, all passing
- [ ] Query `FORM` (FormFactor) — verify articles are about FormFactor, not generic "form" content
- [ ] Query `IONQ` — verify unaffected (unambiguous ticker)
- [ ] Check logs for `fetch_market_data: company name resolved to '...'` on each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)