### PR TITLE
News API comparison tool with SSE streaming

### DIFF
--- a/.claude/agents/code-builder.md
+++ b/.claude/agents/code-builder.md
@@ -1,0 +1,28 @@
+---
+name: code-builder
+description: Implement features and write production code. Use when building new functionality, editing existing modules, or adding new API endpoints.
+tools: Read, Edit, Write, Bash, Glob, Grep
+model: sonnet
+---
+
+You are an expert Python software engineer implementing features for QSent, a sentiment analysis pipeline for quantum computing stocks.
+
+## Project Stack
+- FastAPI (REST API)
+- LangGraph (pipeline orchestration)
+- Python 3.11, pytest for testing
+- Virtual environment at `.venv/`
+
+## Key Source Files
+- `src/qsf/api/main.py` — FastAPI app and endpoints
+- `src/qsf/agents/workflow.py` — LangGraph pipeline
+- `src/qsf/ingestion/` — market, news, social data providers
+- `src/qsf/nlp/sentiment.py` — FinBERT sentiment model
+- `src/qsf/common/` — shared utilities and abstractions
+
+## Guidelines
+- Follow existing code patterns and conventions in the codebase
+- Use the Protocol abstractions in `src/qsf/common/providers.py` when adding new providers
+- Do not over-engineer — only build what is specified in the plan
+- Do not add comments or docstrings unless the logic is non-obvious
+- After implementing, verify the code runs without syntax errors using `.venv/bin/python -c "import qsf"`

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,23 @@
+---
+name: code-reviewer
+description: Review code for quality, security, and consistency with existing patterns. Use before finalizing changes or creating a PR.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a senior code reviewer for QSent, a Python sentiment analysis pipeline.
+
+## Review Checklist
+- **Correctness** — does the implementation match what was planned?
+- **Security** — no exposed secrets, no unvalidated external input passed to shell commands, no open redirects
+- **Consistency** — follows existing patterns (Protocol abstractions, LangGraph state, FastAPI conventions)
+- **Simplicity** — no over-engineering, no premature abstractions, no unused code
+- **Test coverage** — are the happy path and key failure modes covered?
+
+## Output Format
+Group feedback by severity:
+- **Critical** — must fix before merging
+- **Warning** — should fix
+- **Suggestion** — optional improvement
+
+If no issues, say so clearly.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,20 @@
+---
+name: test-runner
+description: Run tests and fix failures after code changes. Use after implementation to verify correctness.
+tools: Bash, Read, Edit, Glob, Grep
+model: haiku
+---
+
+You are a test engineer for QSent, a Python sentiment analysis pipeline.
+
+## Running Tests
+```bash
+.venv/bin/pytest
+```
+
+## Guidelines
+- Run the full test suite first, then identify failures
+- Fix failing tests — do not delete or skip them unless they are clearly obsolete
+- If new functionality was added, check whether test coverage is missing and flag it
+- Use `pytest-mock` for mocking external API calls (NewsAPI, Reddit, HuggingFace, yfinance)
+- Report a summary: tests passed, failed, and any coverage gaps found

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "defaultMode": "plan"
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_client_secret
 REDDIT_USER_AGENT=qsent/0.1
 HUGGINGFACE_API_KEY=your_huggingface_api_key
+OPENAI_API_KEY=your_openai_api_key
+MASSIVE_API_KEY=your_massive_api_key
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_api_key
+MARKETAUX_API_KEY=your_marketaux_api_key

--- a/news_comparison.html
+++ b/news_comparison.html
@@ -95,6 +95,65 @@
       color: #f26c6c;
       font-style: italic;
     }
+    /* Spinner */
+    .spinner {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border: 2px solid #555;
+      border-top-color: #4f6ef7;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin-left: 8px;
+      vertical-align: middle;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    /* Article feed */
+    .feed-toggle {
+      background: none;
+      border: none;
+      color: #4f6ef7;
+      cursor: pointer;
+      font-size: 0.8rem;
+      padding: 0.5rem 0;
+      text-align: left;
+      align-self: auto;
+      margin-top: 0.75rem;
+      display: block;
+    }
+    .article-feed {
+      display: none;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-top: 0.5rem;
+    }
+    .article-feed.open { display: flex; }
+    .article-card {
+      border: 1px solid #2a2d3e;
+      border-radius: 6px;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 0.75rem;
+    }
+    .article-text {
+      flex: 1;
+      color: #ccc;
+      line-height: 1.4;
+    }
+    .article-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.25rem;
+      min-width: 90px;
+    }
+    .article-date { color: #666; font-size: 0.75rem; }
+    .label-relevant   { color: #4ecb71; font-weight: 600; }
+    .label-irrelevant { color: #f26c6c; font-weight: 600; }
+    .classifying-cell { color: #888; font-style: italic; font-size: 0.85rem; }
   </style>
 </head>
 <body>
@@ -106,12 +165,14 @@
     <button id="runBtn" onclick="runComparison()">Run Comparison</button>
   </div>
 
-  <div id="status">This may take 1-2 minutes per ticker while GPT classifies articles.</div>
+  <div id="status">Results stream in as each article is classified — no waiting for the full run.</div>
 
   <div id="results" class="results"></div>
 
   <script>
-    async function runComparison() {
+    let currentSource = null;
+
+    function runComparison() {
       const raw = document.getElementById("tickers").value;
       const tickers = raw.split(",").map(t => t.trim()).filter(t => t.length > 0);
       if (tickers.length === 0) {
@@ -119,113 +180,197 @@
         return;
       }
 
+      if (currentSource) { currentSource.close(); currentSource = null; }
+
       const btn = document.getElementById("runBtn");
       const status = document.getElementById("status");
       const resultsEl = document.getElementById("results");
 
       btn.disabled = true;
-      status.textContent = `Running comparison for ${tickers.join(", ")}... This may take 1-2 minutes.`;
+      status.textContent = `Streaming results for ${tickers.join(", ")}...`;
       resultsEl.innerHTML = "";
 
-      try {
-        const res = await fetch("http://localhost:8000/diagnostics/news-comparison", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ tickers }),
-        });
+      const params = tickers.map(t => `tickers=${encodeURIComponent(t)}`).join("&");
+      currentSource = new EventSource(`http://localhost:8000/diagnostics/news-comparison/stream?${params}`);
 
-        if (!res.ok) {
-          const err = await res.json();
-          status.textContent = `Error: ${err.detail || res.statusText}`;
-          return;
-        }
+      currentSource.addEventListener("ticker_start", e => {
+        const { ticker, company } = JSON.parse(e.data);
 
-        const data = await res.json();
-        renderResults(data);
-        status.textContent = "Comparison complete.";
-      } catch (e) {
-        status.textContent = `Failed to connect to API: ${e.message}`;
-      } finally {
-        btn.disabled = false;
-      }
-    }
-
-    function renderResults(data) {
-      const resultsEl = document.getElementById("results");
-      resultsEl.innerHTML = "";
-
-      for (const tickerResult of data.results) {
         const card = document.createElement("div");
         card.className = "ticker-card";
+        card.id = `card-${ticker}`;
 
-        const heading = document.createElement("h2");
-        heading.textContent = tickerResult.ticker;
-        card.appendChild(heading);
+        const h2 = document.createElement("h2");
+        h2.innerHTML = `${ticker}<span class="spinner" id="spinner-${ticker}"></span>`;
+        card.appendChild(h2);
 
-        const company = document.createElement("div");
-        company.className = "company";
-        company.textContent = tickerResult.company || "(company name unknown)";
-        card.appendChild(company);
+        const co = document.createElement("div");
+        co.className = "company";
+        co.textContent = company || "(company name unknown)";
+        card.appendChild(co);
 
         const table = document.createElement("table");
         table.innerHTML = `
-          <thead>
-            <tr>
-              <th>API</th>
-              <th>Total Articles</th>
-              <th>Relevant</th>
-              <th>Precision (%)</th>
-              <th>Free Tier Limit</th>
-            </tr>
-          </thead>
-          <tbody id="tbody-${tickerResult.ticker}"></tbody>
-        `;
+          <thead><tr>
+            <th>API</th><th>Total Articles</th><th>Relevant</th>
+            <th>Precision (%)</th><th>Free Tier Limit</th>
+          </tr></thead>
+          <tbody id="tbody-${ticker}"></tbody>`;
         card.appendChild(table);
+
+        const feedsContainer = document.createElement("div");
+        feedsContainer.id = `feeds-${ticker}`;
+        card.appendChild(feedsContainer);
+
         resultsEl.appendChild(card);
+      });
 
-        const providers = tickerResult.providers;
-        const tbody = document.getElementById(`tbody-${tickerResult.ticker}`);
+      currentSource.addEventListener("provider_start", e => {
+        const { ticker, provider, total } = JSON.parse(e.data);
 
-        // Find best and worst precision among valid (non-error) rows
-        const validPrecisions = providers
-          .filter(p => p.error === null && p.total > 0)
-          .map(p => p.precision);
-
-        const maxPrecision = validPrecisions.length > 0 ? Math.max(...validPrecisions) : null;
-        const minPrecision = validPrecisions.length > 1 ? Math.min(...validPrecisions) : null;
-
-        for (const provider of providers) {
+        const tbody = document.getElementById(`tbody-${ticker}`);
+        if (tbody) {
           const row = document.createElement("tr");
-
-          if (provider.error !== null) {
-            row.innerHTML = `
-              <td>${provider.name}</td>
-              <td colspan="3" class="error-cell">${provider.error}</td>
-              <td>${provider.free_tier}</td>
-            `;
-          } else {
-            const precisionPct = provider.total > 0
-              ? (provider.precision * 100).toFixed(1) + "%"
-              : "—";
-
-            if (maxPrecision !== null && provider.precision === maxPrecision) {
-              row.className = "best";
-            } else if (minPrecision !== null && provider.precision === minPrecision) {
-              row.className = "worst";
-            }
-
-            row.innerHTML = `
-              <td>${provider.name}</td>
-              <td>${provider.total}</td>
-              <td>${provider.relevant}</td>
-              <td>${precisionPct}</td>
-              <td>${provider.free_tier}</td>
-            `;
-          }
-
+          row.id = `row-${ticker}-${provider}`;
+          row.innerHTML = `
+            <td>${provider}</td>
+            <td colspan="3" class="classifying-cell">Classifying ${total} article${total === 1 ? "" : "s"}…</td>
+            <td></td>`;
           tbody.appendChild(row);
         }
-      }
+
+        const feedsContainer = document.getElementById(`feeds-${ticker}`);
+        if (feedsContainer) {
+          const section = document.createElement("div");
+          section.id = `feed-section-${ticker}-${provider}`;
+
+          const toggle = document.createElement("button");
+          toggle.className = "feed-toggle";
+          toggle.textContent = `▶ ${provider} articles (${total})`;
+          toggle.onclick = () => {
+            const feed = document.getElementById(`feed-${ticker}-${provider}`);
+            const open = feed.classList.toggle("open");
+            toggle.textContent = `${open ? "▼" : "▶"} ${provider} articles (${total})`;
+          };
+          section.appendChild(toggle);
+
+          const feed = document.createElement("div");
+          feed.className = "article-feed";
+          feed.id = `feed-${ticker}-${provider}`;
+          section.appendChild(feed);
+
+          feedsContainer.appendChild(section);
+        }
+      });
+
+      currentSource.addEventListener("article_result", e => {
+        const { ticker, provider, text, date, relevant } = JSON.parse(e.data);
+        const feed = document.getElementById(`feed-${ticker}-${provider}`);
+        if (!feed) return;
+
+        const truncated = text;
+        const label = relevant
+          ? `<span class="label-relevant">✓ relevant</span>`
+          : `<span class="label-irrelevant">✗ not relevant</span>`;
+
+        const card = document.createElement("div");
+        card.className = "article-card";
+        card.innerHTML = `
+          <span class="article-text">${escapeHtml(truncated)}</span>
+          <span class="article-meta">
+            <span class="article-date">${date}</span>
+            ${label}
+          </span>`;
+        feed.appendChild(card);
+      });
+
+      currentSource.addEventListener("provider_done", e => {
+        const { ticker, provider, total, relevant, precision, free_tier } = JSON.parse(e.data);
+        const row = document.getElementById(`row-${ticker}-${provider}`);
+        if (!row) return;
+
+        const precisionPct = total > 0 ? (precision * 100).toFixed(1) + "%" : "—";
+        row.innerHTML = `
+          <td>${provider}</td>
+          <td>${total}</td>
+          <td>${relevant}</td>
+          <td>${precisionPct}</td>
+          <td>${free_tier}</td>`;
+
+        applyBestWorst(ticker);
+      });
+
+      currentSource.addEventListener("provider_error", e => {
+        const { ticker, provider, error, free_tier } = JSON.parse(e.data);
+        const tbody = document.getElementById(`tbody-${ticker}`);
+        if (!tbody) return;
+
+        let row = document.getElementById(`row-${ticker}-${provider}`);
+        if (!row) {
+          row = document.createElement("tr");
+          row.id = `row-${ticker}-${provider}`;
+          tbody.appendChild(row);
+        }
+        row.innerHTML = `
+          <td>${provider}</td>
+          <td colspan="3" class="error-cell">${escapeHtml(error)}</td>
+          <td>${free_tier || ""}</td>`;
+      });
+
+      currentSource.addEventListener("done", () => {
+        document.getElementById("status").textContent = "Comparison complete.";
+        document.getElementById("runBtn").disabled = false;
+        currentSource.close();
+        currentSource = null;
+
+        // Final best/worst pass and remove all spinners
+        document.querySelectorAll(".ticker-card").forEach(card => {
+          applyBestWorst(card.id.replace("card-", ""));
+        });
+        document.querySelectorAll(".spinner").forEach(s => s.remove());
+      });
+
+      currentSource.onerror = () => {
+        document.getElementById("status").textContent = "Stream disconnected. Server may have finished or an error occurred.";
+        document.getElementById("runBtn").disabled = false;
+        document.querySelectorAll(".spinner").forEach(s => s.remove());
+        if (currentSource) { currentSource.close(); currentSource = null; }
+      };
+    }
+
+    function applyBestWorst(ticker) {
+      const tbody = document.getElementById(`tbody-${ticker}`);
+      if (!tbody) return;
+
+      const data = Array.from(tbody.querySelectorAll("tr")).map(row => {
+        const cells = row.querySelectorAll("td");
+        if (cells.length < 4) return null;
+        const precText = cells[3].textContent.trim();
+        if (!precText || precText === "—") return null;
+        return { row, val: parseFloat(precText) / 100 };
+      }).filter(Boolean);
+
+      if (data.length === 0) return;
+
+      const vals = data.map(d => d.val);
+      const max = Math.max(...vals);
+      const min = Math.min(...vals);
+
+      data.forEach(({ row, val }) => {
+        row.className = "";
+        if (val === max) row.className = "best";
+        else if (val === min && vals.length > 1 && vals.filter(v => v === min).length < vals.length) {
+          row.className = "worst";
+        }
+      });
+    }
+
+    function escapeHtml(str) {
+      return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
     }
   </script>
 </body>

--- a/news_comparison.html
+++ b/news_comparison.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>QSent - News API Comparison</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0f1117;
+      color: #e0e0e0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 2rem;
+      min-height: 100vh;
+    }
+    h1 { font-size: 1.4rem; margin-bottom: 0.5rem; letter-spacing: 0.05em; color: #fff; }
+    .subtitle { font-size: 0.85rem; color: #888; margin-bottom: 1.5rem; }
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+      width: 100%;
+      max-width: 600px;
+    }
+    textarea {
+      padding: 0.5rem 1rem;
+      font-size: 1rem;
+      border-radius: 6px;
+      border: 1px solid #333;
+      background: #1c1f2e;
+      color: #fff;
+      resize: vertical;
+      min-height: 60px;
+      font-family: system-ui, sans-serif;
+    }
+    button {
+      padding: 0.5rem 1.25rem;
+      font-size: 1rem;
+      border-radius: 6px;
+      border: none;
+      background: #4f6ef7;
+      color: #fff;
+      cursor: pointer;
+      align-self: flex-start;
+    }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    #status { font-size: 0.85rem; color: #888; margin-bottom: 1.5rem; min-height: 1.2em; }
+    .results {
+      width: 100%;
+      max-width: 900px;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+    .ticker-card {
+      background: #1c1f2e;
+      border-radius: 12px;
+      padding: 1.5rem;
+    }
+    .ticker-card h2 {
+      font-size: 1.1rem;
+      margin-bottom: 0.25rem;
+      color: #fff;
+    }
+    .ticker-card .company {
+      font-size: 0.8rem;
+      color: #888;
+      margin-bottom: 1rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+    th {
+      text-align: left;
+      color: #aaa;
+      font-weight: 500;
+      padding: 0.4rem 0.75rem;
+      border-bottom: 1px solid #2a2d3e;
+    }
+    td {
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid #1a1d2b;
+    }
+    tr:last-child td { border-bottom: none; }
+    .best td { color: #4ecb71; }
+    .worst td { color: #f26c6c; }
+    .error-cell {
+      font-size: 0.8rem;
+      color: #f26c6c;
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <h1>QSent &mdash; News API Comparison</h1>
+  <p class="subtitle">Compare news providers for ticker relevance precision</p>
+
+  <div class="controls">
+    <textarea id="tickers" placeholder="IONQ, FORM, RGTI">IONQ, FORM, RGTI</textarea>
+    <button id="runBtn" onclick="runComparison()">Run Comparison</button>
+  </div>
+
+  <div id="status">This may take 1-2 minutes per ticker while GPT classifies articles.</div>
+
+  <div id="results" class="results"></div>
+
+  <script>
+    async function runComparison() {
+      const raw = document.getElementById("tickers").value;
+      const tickers = raw.split(",").map(t => t.trim()).filter(t => t.length > 0);
+      if (tickers.length === 0) {
+        document.getElementById("status").textContent = "Please enter at least one ticker.";
+        return;
+      }
+
+      const btn = document.getElementById("runBtn");
+      const status = document.getElementById("status");
+      const resultsEl = document.getElementById("results");
+
+      btn.disabled = true;
+      status.textContent = `Running comparison for ${tickers.join(", ")}... This may take 1-2 minutes.`;
+      resultsEl.innerHTML = "";
+
+      try {
+        const res = await fetch("http://localhost:8000/diagnostics/news-comparison", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tickers }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json();
+          status.textContent = `Error: ${err.detail || res.statusText}`;
+          return;
+        }
+
+        const data = await res.json();
+        renderResults(data);
+        status.textContent = "Comparison complete.";
+      } catch (e) {
+        status.textContent = `Failed to connect to API: ${e.message}`;
+      } finally {
+        btn.disabled = false;
+      }
+    }
+
+    function renderResults(data) {
+      const resultsEl = document.getElementById("results");
+      resultsEl.innerHTML = "";
+
+      for (const tickerResult of data.results) {
+        const card = document.createElement("div");
+        card.className = "ticker-card";
+
+        const heading = document.createElement("h2");
+        heading.textContent = tickerResult.ticker;
+        card.appendChild(heading);
+
+        const company = document.createElement("div");
+        company.className = "company";
+        company.textContent = tickerResult.company || "(company name unknown)";
+        card.appendChild(company);
+
+        const table = document.createElement("table");
+        table.innerHTML = `
+          <thead>
+            <tr>
+              <th>API</th>
+              <th>Total Articles</th>
+              <th>Relevant</th>
+              <th>Precision (%)</th>
+              <th>Free Tier Limit</th>
+            </tr>
+          </thead>
+          <tbody id="tbody-${tickerResult.ticker}"></tbody>
+        `;
+        card.appendChild(table);
+        resultsEl.appendChild(card);
+
+        const providers = tickerResult.providers;
+        const tbody = document.getElementById(`tbody-${tickerResult.ticker}`);
+
+        // Find best and worst precision among valid (non-error) rows
+        const validPrecisions = providers
+          .filter(p => p.error === null && p.total > 0)
+          .map(p => p.precision);
+
+        const maxPrecision = validPrecisions.length > 0 ? Math.max(...validPrecisions) : null;
+        const minPrecision = validPrecisions.length > 1 ? Math.min(...validPrecisions) : null;
+
+        for (const provider of providers) {
+          const row = document.createElement("tr");
+
+          if (provider.error !== null) {
+            row.innerHTML = `
+              <td>${provider.name}</td>
+              <td colspan="3" class="error-cell">${provider.error}</td>
+              <td>${provider.free_tier}</td>
+            `;
+          } else {
+            const precisionPct = provider.total > 0
+              ? (provider.precision * 100).toFixed(1) + "%"
+              : "—";
+
+            if (maxPrecision !== null && provider.precision === maxPrecision) {
+              row.className = "best";
+            } else if (minPrecision !== null && provider.precision === minPrecision) {
+              row.className = "worst";
+            }
+
+            row.innerHTML = `
+              <td>${provider.name}</td>
+              <td>${provider.total}</td>
+              <td>${provider.relevant}</td>
+              <td>${precisionPct}</td>
+              <td>${provider.free_tier}</td>
+            `;
+          }
+
+          tbody.appendChild(row);
+        }
+      }
+    }
+  </script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "requests>=2.31",
     "python-dotenv>=1.0",
     "langgraph>=0.2",
+    "openai>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/qsf/agents/news_comparison.py
+++ b/src/qsf/agents/news_comparison.py
@@ -1,0 +1,72 @@
+"""
+News API comparison runner.
+Evaluates multiple news providers for ticker relevance using GPT classification.
+"""
+import logging
+
+from qsf.common.utils import company_search_name
+from qsf.ingestion.market import YFinanceMarketData
+from qsf.ingestion.news import NewsAPIProvider
+from qsf.ingestion.news_alphavantage import AlphaVantageNewsProvider
+from qsf.ingestion.news_marketaux import MarketauxNewsProvider
+from qsf.ingestion.news_massive import MassiveNewsProvider
+from qsf.nlp.relevance import MAX_ARTICLES, RelevanceClassifier
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER_REGISTRY = [
+    ("NewsAPI",      NewsAPIProvider,          "1,000 req/day (30-day history)"),
+    ("Massive",      MassiveNewsProvider,      "5 req/min, unlimited/day (2yr history)"),
+    ("AlphaVantage", AlphaVantageNewsProvider, "25 req/day"),
+    ("Marketaux",    MarketauxNewsProvider,    "100 req/day"),
+]
+
+
+def run_news_comparison(tickers: list[str], providers_config: list[str] | None = None) -> dict:
+    """Compare news API providers across tickers using GPT-based relevance scoring."""
+    classifier = RelevanceClassifier()
+    results = []
+
+    for ticker in tickers:
+        full_name = YFinanceMarketData().get_company_name(ticker)
+        company = company_search_name(full_name)
+
+        provider_results = []
+        for name, provider_cls, free_tier in _PROVIDER_REGISTRY:
+            try:
+                provider = provider_cls()
+                articles = provider.get_articles(ticker, company_name=company)
+                articles_to_classify = articles[:MAX_ARTICLES]
+                relevance = classifier.classify(ticker, company, articles_to_classify)
+                total = len(articles_to_classify)
+                relevant = sum(relevance)
+                precision = relevant / total if total > 0 else 0.0
+                provider_results.append({
+                    "name": name,
+                    "total": total,
+                    "relevant": relevant,
+                    "precision": round(precision, 4),
+                    "free_tier": free_tier,
+                    "error": None,
+                })
+            except Exception as exc:
+                logger.warning("Provider %s failed for %s: %s", name, ticker, exc)
+                provider_results.append({
+                    "name": name,
+                    "total": 0,
+                    "relevant": 0,
+                    "precision": 0.0,
+                    "free_tier": free_tier,
+                    "error": f"{type(exc).__name__}: {exc}",
+                })
+
+        results.append({
+            "ticker": ticker,
+            "company": company,
+            "providers": provider_results,
+        })
+
+    return {
+        "tickers": tickers,
+        "results": results,
+    }

--- a/src/qsf/agents/news_comparison.py
+++ b/src/qsf/agents/news_comparison.py
@@ -2,7 +2,9 @@
 News API comparison runner.
 Evaluates multiple news providers for ticker relevance using GPT classification.
 """
+import json
 import logging
+from typing import Iterator
 
 from qsf.common.utils import company_search_name
 from qsf.ingestion.market import YFinanceMarketData
@@ -70,3 +72,68 @@ def run_news_comparison(tickers: list[str], providers_config: list[str] | None =
         "tickers": tickers,
         "results": results,
     }
+
+
+def run_news_comparison_stream(tickers: list[str]) -> Iterator[str]:
+    """Generator that yields SSE-formatted strings for progressive frontend rendering.
+
+    Event sequence: ticker_start → (per provider) provider_start →
+    article_result* → provider_done | provider_error → done
+    """
+    classifier = RelevanceClassifier()
+
+    def _sse(event: str, data: dict) -> str:
+        return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+    for ticker in tickers:
+        try:
+            company = company_search_name(YFinanceMarketData().get_company_name(ticker))
+        except Exception as exc:
+            logger.warning("Company name resolution failed for %s: %s", ticker, exc)
+            company = ticker
+
+        yield _sse("ticker_start", {"ticker": ticker, "company": company})
+
+        for name, provider_cls, free_tier in _PROVIDER_REGISTRY:
+            try:
+                articles = provider_cls().get_articles(ticker, company_name=company)
+            except Exception as exc:
+                logger.warning("Provider %s failed for %s: %s", name, ticker, exc)
+                yield _sse("provider_error", {
+                    "ticker": ticker, "provider": name,
+                    "error": f"{type(exc).__name__}: {exc}", "free_tier": free_tier,
+                })
+                continue
+
+            articles_to_classify = articles[:MAX_ARTICLES]
+            yield _sse("provider_start", {
+                "ticker": ticker, "provider": name, "total": len(articles_to_classify),
+            })
+
+            relevant_count = 0
+            try:
+                for index, article, relevant in classifier.classify_stream(ticker, company, articles_to_classify):
+                    if relevant:
+                        relevant_count += 1
+                    yield _sse("article_result", {
+                        "ticker": ticker, "provider": name, "index": index,
+                        "text": article.get("text", ""), "date": article.get("date", ""),
+                        "relevant": relevant,
+                    })
+            except Exception as exc:
+                logger.warning("classify_stream raised for %s/%s: %s", name, ticker, exc)
+                yield _sse("provider_error", {
+                    "ticker": ticker, "provider": name,
+                    "error": f"{type(exc).__name__}: {exc}", "free_tier": free_tier,
+                })
+                continue
+
+            total = len(articles_to_classify)
+            yield _sse("provider_done", {
+                "ticker": ticker, "provider": name, "total": total,
+                "relevant": relevant_count,
+                "precision": round(relevant_count / total, 4) if total > 0 else 0.0,
+                "free_tier": free_tier, "error": None,
+            })
+
+    yield _sse("done", {})

--- a/src/qsf/api/main.py
+++ b/src/qsf/api/main.py
@@ -1,11 +1,12 @@
 import logging
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from qsf.agents.news_comparison import run_news_comparison
+from qsf.agents.news_comparison import run_news_comparison, run_news_comparison_stream
 from qsf.agents.workflow import pipeline
 
 load_dotenv()
@@ -52,3 +53,15 @@ def news_comparison(request: NewsComparisonRequest):
     if not tickers:
         raise HTTPException(status_code=422, detail="At least one ticker is required")
     return run_news_comparison(tickers)
+
+
+@app.get("/diagnostics/news-comparison/stream")
+def news_comparison_stream(tickers: list[str] = Query(...)):
+    clean = [t.upper().strip() for t in tickers if t.strip()]
+    if not clean:
+        raise HTTPException(status_code=422, detail="At least one ticker is required")
+    return StreamingResponse(
+        run_news_comparison_stream(clean),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/src/qsf/api/main.py
+++ b/src/qsf/api/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
+from qsf.agents.news_comparison import run_news_comparison
 from qsf.agents.workflow import pipeline
 
 load_dotenv()
@@ -28,6 +29,10 @@ class AnalyzeRequest(BaseModel):
     ticker: str
 
 
+class NewsComparisonRequest(BaseModel):
+    tickers: list[str]
+
+
 @app.get("/health")
 def health():
     return {"status": "ok"}
@@ -39,3 +44,11 @@ def analyze(request: AnalyzeRequest):
     if state.get("error"):
         raise HTTPException(status_code=404, detail=state["error"])
     return state["result"]
+
+
+@app.post("/diagnostics/news-comparison")
+def news_comparison(request: NewsComparisonRequest):
+    tickers = [t.upper().strip() for t in request.tickers if t.strip()]
+    if not tickers:
+        raise HTTPException(status_code=422, detail="At least one ticker is required")
+    return run_news_comparison(tickers)

--- a/src/qsf/ingestion/news_alphavantage.py
+++ b/src/qsf/ingestion/news_alphavantage.py
@@ -1,0 +1,53 @@
+"""
+Alpha Vantage news sentiment provider.
+Supports ticker-based filtering via the NEWS_SENTIMENT function.
+"""
+import os
+from datetime import datetime, timedelta
+
+import requests
+
+
+class AlphaVantageNewsProvider:
+    def get_articles(self, ticker: str, company_name: str = "", days: int = 28) -> list[dict]:
+        api_key = os.getenv("ALPHA_VANTAGE_API_KEY")
+        if not api_key:
+            raise ValueError("ALPHA_VANTAGE_API_KEY not set")
+
+        from_date = (datetime.now() - timedelta(days=days)).strftime("%Y%m%dT%H%M")
+        params = {
+            "function": "NEWS_SENTIMENT",
+            "tickers": ticker,
+            "limit": 50,
+            "time_from": from_date,
+            "apikey": api_key,
+        }
+        response = requests.get("https://www.alphavantage.co/query", params=params)
+        response.raise_for_status()
+        data = response.json()
+
+        if "feed" not in data:
+            raise ValueError(f"Alpha Vantage quota exceeded or invalid response: {data}")
+
+        return [
+            {
+                "text": _article_text(a),
+                "date": _parse_date(a["time_published"]),
+                "source": "news",
+            }
+            for a in data["feed"]
+            if a.get("title")
+        ]
+
+
+def _parse_date(raw: str) -> str:
+    """Parse Alpha Vantage date format '20260210T143022' -> '2026-02-10'."""
+    return f"{raw[:4]}-{raw[4:6]}-{raw[6:8]}"
+
+
+def _article_text(article: dict) -> str:
+    title = article.get("title", "")
+    summary = article.get("summary") or ""
+    if summary:
+        return f"{title}. {summary}"
+    return title

--- a/src/qsf/ingestion/news_marketaux.py
+++ b/src/qsf/ingestion/news_marketaux.py
@@ -1,0 +1,45 @@
+"""
+Marketaux news provider.
+Supports ticker-based filtering via filter_entities parameter.
+"""
+import os
+from datetime import datetime, timedelta
+
+import requests
+
+
+class MarketauxNewsProvider:
+    def get_articles(self, ticker: str, company_name: str = "", days: int = 28) -> list[dict]:
+        api_key = os.getenv("MARKETAUX_API_KEY")
+        if not api_key:
+            raise ValueError("MARKETAUX_API_KEY not set")
+
+        from_date = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+        params = {
+            "symbols": ticker,
+            "filter_entities": "true",
+            "limit": 50,
+            "published_after": from_date,
+            "api_token": api_key,
+        }
+        response = requests.get("https://api.marketaux.com/v1/news/all", params=params)
+        response.raise_for_status()
+        data = response.json()
+
+        return [
+            {
+                "text": _article_text(a),
+                "date": a["published_at"][:10],
+                "source": "news",
+            }
+            for a in data.get("data", [])
+            if a.get("title")
+        ]
+
+
+def _article_text(article: dict) -> str:
+    title = article.get("title", "")
+    description = article.get("description") or ""
+    if description:
+        return f"{title}. {description}"
+    return title

--- a/src/qsf/ingestion/news_massive.py
+++ b/src/qsf/ingestion/news_massive.py
@@ -1,0 +1,44 @@
+"""
+Massive.com (formerly Polygon.io) news provider.
+Supports ticker-based filtering via the reference/news endpoint.
+"""
+import os
+from datetime import datetime, timedelta
+
+import requests
+
+
+class MassiveNewsProvider:
+    def get_articles(self, ticker: str, company_name: str = "", days: int = 28) -> list[dict]:
+        api_key = os.getenv("MASSIVE_API_KEY")
+        if not api_key:
+            raise ValueError("MASSIVE_API_KEY not set")
+
+        from_date = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+        params = {
+            "ticker": ticker,
+            "limit": 50,
+            "published_utc.gte": from_date,
+            "apiKey": api_key,
+        }
+        response = requests.get("https://api.massive.com/v2/reference/news", params=params)
+        response.raise_for_status()
+        data = response.json()
+
+        return [
+            {
+                "text": _article_text(a),
+                "date": a["published_utc"][:10],
+                "source": "news",
+            }
+            for a in data.get("results", [])
+            if a.get("title")
+        ]
+
+
+def _article_text(article: dict) -> str:
+    title = article.get("title", "")
+    description = article.get("description") or ""
+    if description:
+        return f"{title}. {description}"
+    return title

--- a/src/qsf/nlp/relevance.py
+++ b/src/qsf/nlp/relevance.py
@@ -1,0 +1,52 @@
+"""
+GPT-based relevance classifier for news articles.
+Determines whether an article is specifically about a given company/ticker.
+"""
+import logging
+import os
+
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+MAX_ARTICLES = 20  # hard cap per provider to limit GPT spend
+
+
+class RelevanceClassifier:
+    def classify(self, ticker: str, company_name: str, articles: list[dict]) -> list[bool]:
+        """Classify each article as relevant (True) or not (False).
+
+        Only classifies up to MAX_ARTICLES; positions beyond the cap default to False.
+        Returns a list of the same length as articles.
+        """
+        if not articles:
+            return []
+
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        articles_to_classify = articles[:MAX_ARTICLES]
+        results: list[bool] = []
+
+        for article in articles_to_classify:
+            text = article.get("text", "")
+            prompt = (
+                f"Is this article specifically about {company_name} (ticker: ${ticker}) "
+                f"and relevant to its stock, financials, or business? "
+                f"Reply only 'yes' or 'no'.\n\n{text}"
+            )
+            try:
+                response = client.chat.completions.create(
+                    model="gpt-4.1-nano",  # update to latest available model as needed
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=3,
+                    temperature=0,
+                )
+                answer = response.choices[0].message.content.strip().lower()
+                results.append(answer == "yes")
+            except Exception as exc:
+                logger.warning("Relevance classification failed: %s", exc)
+                results.append(False)
+
+        # Positions beyond cap default to False
+        beyond_cap = len(articles) - len(articles_to_classify)
+        results.extend([False] * beyond_cap)
+        return results

--- a/src/qsf/nlp/relevance.py
+++ b/src/qsf/nlp/relevance.py
@@ -4,6 +4,7 @@ Determines whether an article is specifically about a given company/ticker.
 """
 import logging
 import os
+from typing import Iterator
 
 from openai import OpenAI
 
@@ -50,3 +51,43 @@ class RelevanceClassifier:
         beyond_cap = len(articles) - len(articles_to_classify)
         results.extend([False] * beyond_cap)
         return results
+
+    def classify_stream(
+        self,
+        ticker: str,
+        company_name: str,
+        articles: list[dict],
+    ) -> Iterator[tuple[int, dict, bool]]:
+        """Like classify(), but yields (index, article, relevant) one at a time.
+
+        Same cap, prompt, and error-handling behaviour as classify().
+        Positions beyond MAX_ARTICLES are yielded as (index, article, False)
+        without an API call, matching classify()'s beyond_cap padding.
+        """
+        if not articles:
+            return
+
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        for i, article in enumerate(articles[:MAX_ARTICLES]):
+            text = article.get("text", "")
+            prompt = (
+                f"Is this article specifically about {company_name} (ticker: ${ticker}) "
+                f"and relevant to its stock, financials, or business? "
+                f"Reply only 'yes' or 'no'.\n\n{text}"
+            )
+            try:
+                response = client.chat.completions.create(
+                    model="gpt-4.1-nano",
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=3,
+                    temperature=0,
+                )
+                relevant = response.choices[0].message.content.strip().lower() == "yes"
+            except Exception as exc:
+                logger.warning("Relevance classification failed: %s", exc)
+                relevant = False
+            yield i, article, relevant
+
+        # Beyond-cap positions: yield False without API call
+        for j, article in enumerate(articles[MAX_ARTICLES:], start=MAX_ARTICLES):
+            yield j, article, False

--- a/tests/integration/test_news_comparison_endpoint.py
+++ b/tests/integration/test_news_comparison_endpoint.py
@@ -1,0 +1,88 @@
+"""
+Integration tests for the /diagnostics/news-comparison endpoint.
+"""
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qsf.api.main import app
+
+client = TestClient(app)
+
+MOCK_COMPARISON_RESULT = {
+    "tickers": ["IONQ"],
+    "results": [
+        {
+            "ticker": "IONQ",
+            "company": "IonQ",
+            "providers": [
+                {"name": "NewsAPI", "total": 20, "relevant": 15, "precision": 0.75, "free_tier": "1,000 req/day (30-day history)", "error": None},
+                {"name": "Massive", "total": 10, "relevant": 8, "precision": 0.8, "free_tier": "5 req/min, unlimited/day (2yr history)", "error": None},
+            ],
+        }
+    ],
+}
+
+
+@patch("qsf.api.main.run_news_comparison")
+def test_valid_request_returns_200_with_correct_shape(mock_runner):
+    mock_runner.return_value = MOCK_COMPARISON_RESULT
+    response = client.post("/diagnostics/news-comparison", json={"tickers": ["IONQ"]})
+    assert response.status_code == 200
+    data = response.json()
+    assert "tickers" in data
+    assert "results" in data
+    assert data["results"][0]["ticker"] == "IONQ"
+    assert "providers" in data["results"][0]
+
+
+@patch("qsf.api.main.run_news_comparison")
+def test_tickers_are_uppercased(mock_runner):
+    mock_runner.return_value = MOCK_COMPARISON_RESULT
+    client.post("/diagnostics/news-comparison", json={"tickers": ["ionq", "form"]})
+    call_args = mock_runner.call_args[0][0]
+    assert "IONQ" in call_args
+    assert "FORM" in call_args
+
+
+@patch("qsf.api.main.run_news_comparison")
+def test_whitespace_tickers_filtered_out(mock_runner):
+    mock_runner.return_value = MOCK_COMPARISON_RESULT
+    client.post("/diagnostics/news-comparison", json={"tickers": ["IONQ", "  ", "FORM"]})
+    call_args = mock_runner.call_args[0][0]
+    assert "  " not in call_args
+    assert len(call_args) == 2
+
+
+def test_all_empty_tickers_returns_422():
+    response = client.post("/diagnostics/news-comparison", json={"tickers": ["  ", ""]})
+    assert response.status_code == 422
+
+
+def test_missing_tickers_field_returns_422():
+    response = client.post("/diagnostics/news-comparison", json={})
+    assert response.status_code == 422
+
+
+@patch("qsf.api.main.run_news_comparison")
+def test_provider_error_returns_200_with_error_in_payload(mock_runner):
+    """Provider-level errors are captured in the payload, not as HTTP errors."""
+    result_with_error = {
+        "tickers": ["IONQ"],
+        "results": [
+            {
+                "ticker": "IONQ",
+                "company": "IonQ",
+                "providers": [
+                    {"name": "NewsAPI", "total": 0, "relevant": 0, "precision": 0.0,
+                     "free_tier": "1,000 req/day (30-day history)", "error": "ValueError: NEWS_API_KEY not set"},
+                ],
+            }
+        ],
+    }
+    mock_runner.return_value = result_with_error
+    response = client.post("/diagnostics/news-comparison", json={"tickers": ["IONQ"]})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"][0]["providers"][0]["error"] is not None

--- a/tests/integration/test_news_comparison_endpoint.py
+++ b/tests/integration/test_news_comparison_endpoint.py
@@ -1,6 +1,7 @@
 """
 Integration tests for the /diagnostics/news-comparison endpoint.
 """
+import json
 from unittest.mock import patch
 
 import pytest
@@ -86,3 +87,101 @@ def test_provider_error_returns_200_with_error_in_payload(mock_runner):
     assert response.status_code == 200
     data = response.json()
     assert data["results"][0]["providers"][0]["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming endpoint tests
+# ---------------------------------------------------------------------------
+
+def _parse_sse(raw: str) -> list[dict]:
+    """Parse raw SSE text into list of {event, data} dicts."""
+    messages = []
+    for block in raw.strip().split("\n\n"):
+        block = block.strip()
+        if not block:
+            continue
+        event = None
+        data = None
+        for line in block.split("\n"):
+            if line.startswith("event: "):
+                event = line[len("event: "):]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: "):])
+        if event is not None and data is not None:
+            messages.append({"event": event, "data": data})
+    return messages
+
+
+def _mock_stream(tickers):
+    def _sse(event, data):
+        return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+    yield _sse("ticker_start", {"ticker": "IONQ", "company": "IonQ"})
+    yield _sse("provider_start", {"ticker": "IONQ", "provider": "NewsAPI", "total": 1})
+    yield _sse("article_result", {
+        "ticker": "IONQ", "provider": "NewsAPI",
+        "index": 0, "text": "IonQ article", "date": "2026-02-10", "relevant": True,
+    })
+    yield _sse("provider_done", {
+        "ticker": "IONQ", "provider": "NewsAPI",
+        "total": 1, "relevant": 1, "precision": 1.0,
+        "free_tier": "1,000 req/day (30-day history)", "error": None,
+    })
+    yield _sse("done", {})
+
+
+@patch("qsf.api.main.run_news_comparison_stream")
+def test_stream_returns_text_event_stream(mock_stream):
+    mock_stream.side_effect = _mock_stream
+    response = client.get("/diagnostics/news-comparison/stream?tickers=IONQ")
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+
+
+@patch("qsf.api.main.run_news_comparison_stream")
+def test_stream_emits_all_expected_event_types(mock_stream):
+    mock_stream.side_effect = _mock_stream
+    response = client.get("/diagnostics/news-comparison/stream?tickers=IONQ")
+    event_types = [m["event"] for m in _parse_sse(response.text)]
+    for expected in ("ticker_start", "provider_start", "article_result", "provider_done", "done"):
+        assert expected in event_types
+
+
+@patch("qsf.api.main.run_news_comparison_stream")
+def test_stream_ticker_start_payload(mock_stream):
+    mock_stream.side_effect = _mock_stream
+    response = client.get("/diagnostics/news-comparison/stream?tickers=IONQ")
+    messages = _parse_sse(response.text)
+    start = next(m for m in messages if m["event"] == "ticker_start")
+    assert start["data"]["ticker"] == "IONQ"
+    assert start["data"]["company"] == "IonQ"
+
+
+@patch("qsf.api.main.run_news_comparison_stream")
+def test_stream_article_result_has_required_fields(mock_stream):
+    mock_stream.side_effect = _mock_stream
+    response = client.get("/diagnostics/news-comparison/stream?tickers=IONQ")
+    messages = _parse_sse(response.text)
+    ar = next(m for m in messages if m["event"] == "article_result")
+    for field in ("ticker", "provider", "index", "text", "date", "relevant"):
+        assert field in ar["data"]
+
+
+@patch("qsf.api.main.run_news_comparison_stream")
+def test_stream_done_event_is_last(mock_stream):
+    mock_stream.side_effect = _mock_stream
+    response = client.get("/diagnostics/news-comparison/stream?tickers=IONQ")
+    messages = _parse_sse(response.text)
+    assert messages[-1]["event"] == "done"
+
+
+def test_stream_empty_tickers_returns_422():
+    response = client.get("/diagnostics/news-comparison/stream?tickers=&tickers=")
+    assert response.status_code == 422
+
+
+@patch("qsf.api.main.run_news_comparison_stream")
+def test_stream_tickers_are_uppercased(mock_stream):
+    mock_stream.side_effect = _mock_stream
+    client.get("/diagnostics/news-comparison/stream?tickers=ionq")
+    call_args = mock_stream.call_args[0][0]
+    assert "IONQ" in call_args

--- a/tests/unit/test_news_providers_financial.py
+++ b/tests/unit/test_news_providers_financial.py
@@ -1,0 +1,148 @@
+"""
+Unit tests for the financial news providers (Massive, AlphaVantage, Marketaux).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qsf.ingestion.news_alphavantage import AlphaVantageNewsProvider
+from qsf.ingestion.news_marketaux import MarketauxNewsProvider
+from qsf.ingestion.news_massive import MassiveNewsProvider
+
+
+# ---------------------------------------------------------------------------
+# MassiveNewsProvider
+# ---------------------------------------------------------------------------
+
+class TestMassiveNewsProvider:
+    @patch("qsf.ingestion.news_massive.requests.get")
+    def test_returns_correctly_shaped_items(self, mock_get, monkeypatch):
+        monkeypatch.setenv("MASSIVE_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {
+            "results": [
+                {"title": "IonQ beats earnings", "description": "Strong Q4 results.", "published_utc": "2026-02-10T10:00:00Z"},
+                {"title": "Quantum stocks rise", "description": None, "published_utc": "2026-02-11T14:00:00Z"},
+            ]
+        }
+        mock_get.return_value.raise_for_status = MagicMock()
+        items = MassiveNewsProvider().get_articles("IONQ")
+        assert len(items) == 2
+        assert items[0]["text"] == "IonQ beats earnings. Strong Q4 results."
+        assert items[0]["date"] == "2026-02-10"
+        assert items[0]["source"] == "news"
+
+    @patch("qsf.ingestion.news_massive.requests.get")
+    def test_skips_articles_with_no_title(self, mock_get, monkeypatch):
+        monkeypatch.setenv("MASSIVE_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {
+            "results": [
+                {"title": None, "description": "Some description.", "published_utc": "2026-02-10T10:00:00Z"},
+                {"title": "Valid article", "description": None, "published_utc": "2026-02-10T10:00:00Z"},
+            ]
+        }
+        mock_get.return_value.raise_for_status = MagicMock()
+        items = MassiveNewsProvider().get_articles("IONQ")
+        assert len(items) == 1
+        assert items[0]["text"] == "Valid article"
+
+    def test_raises_on_missing_key(self, monkeypatch):
+        monkeypatch.delenv("MASSIVE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="MASSIVE_API_KEY not set"):
+            MassiveNewsProvider().get_articles("IONQ")
+
+    @patch("qsf.ingestion.news_massive.requests.get")
+    def test_passes_ticker_param(self, mock_get, monkeypatch):
+        monkeypatch.setenv("MASSIVE_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {"results": []}
+        mock_get.return_value.raise_for_status = MagicMock()
+        MassiveNewsProvider().get_articles("FORM")
+        call_kwargs = mock_get.call_args
+        params = call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs[0][1]
+        assert params["ticker"] == "FORM"
+
+
+# ---------------------------------------------------------------------------
+# AlphaVantageNewsProvider
+# ---------------------------------------------------------------------------
+
+class TestAlphaVantageNewsProvider:
+    @patch("qsf.ingestion.news_alphavantage.requests.get")
+    def test_returns_correctly_shaped_items(self, mock_get, monkeypatch):
+        monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {
+            "feed": [
+                {"title": "IonQ beats earnings", "summary": "Strong Q4 results.", "time_published": "20260210T143022"},
+                {"title": "Quantum stocks rise", "summary": None, "time_published": "20260211T090000"},
+            ]
+        }
+        mock_get.return_value.raise_for_status = MagicMock()
+        items = AlphaVantageNewsProvider().get_articles("IONQ")
+        assert len(items) == 2
+        assert items[0]["text"] == "IonQ beats earnings. Strong Q4 results."
+        assert items[0]["date"] == "2026-02-10"
+        assert items[0]["source"] == "news"
+
+    @patch("qsf.ingestion.news_alphavantage.requests.get")
+    def test_date_parsing_uses_parse_date_not_slice(self, mock_get, monkeypatch):
+        """time_published[:10] would give '20260210T1' — _parse_date() must be used."""
+        monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {
+            "feed": [
+                {"title": "Test article", "summary": "", "time_published": "20260210T143022"},
+            ]
+        }
+        mock_get.return_value.raise_for_status = MagicMock()
+        items = AlphaVantageNewsProvider().get_articles("IONQ")
+        assert items[0]["date"] == "2026-02-10"
+
+    @patch("qsf.ingestion.news_alphavantage.requests.get")
+    def test_raises_on_quota_response(self, mock_get, monkeypatch):
+        monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {
+            "Information": "Thank you for using Alpha Vantage! Our standard API rate limit is 25 requests per day."
+        }
+        mock_get.return_value.raise_for_status = MagicMock()
+        with pytest.raises(ValueError):
+            AlphaVantageNewsProvider().get_articles("IONQ")
+
+    def test_raises_on_missing_key(self, monkeypatch):
+        monkeypatch.delenv("ALPHA_VANTAGE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="ALPHA_VANTAGE_API_KEY not set"):
+            AlphaVantageNewsProvider().get_articles("IONQ")
+
+
+# ---------------------------------------------------------------------------
+# MarketauxNewsProvider
+# ---------------------------------------------------------------------------
+
+class TestMarketauxNewsProvider:
+    @patch("qsf.ingestion.news_marketaux.requests.get")
+    def test_returns_correctly_shaped_items(self, mock_get, monkeypatch):
+        monkeypatch.setenv("MARKETAUX_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {
+            "data": [
+                {"title": "IonQ beats earnings", "description": "Strong Q4 results.", "published_at": "2026-02-10T10:00:00+00:00"},
+                {"title": "Quantum stocks rise", "description": None, "published_at": "2026-02-11T14:00:00+00:00"},
+            ]
+        }
+        mock_get.return_value.raise_for_status = MagicMock()
+        items = MarketauxNewsProvider().get_articles("IONQ")
+        assert len(items) == 2
+        assert items[0]["text"] == "IonQ beats earnings. Strong Q4 results."
+        assert items[0]["date"] == "2026-02-10"
+        assert items[0]["source"] == "news"
+
+    @patch("qsf.ingestion.news_marketaux.requests.get")
+    def test_sends_filter_entities_true(self, mock_get, monkeypatch):
+        monkeypatch.setenv("MARKETAUX_API_KEY", "test-key")
+        mock_get.return_value.json.return_value = {"data": []}
+        mock_get.return_value.raise_for_status = MagicMock()
+        MarketauxNewsProvider().get_articles("FORM")
+        call_kwargs = mock_get.call_args
+        params = call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs[0][1]
+        assert params["filter_entities"] == "true"
+
+    def test_raises_on_missing_key(self, monkeypatch):
+        monkeypatch.delenv("MARKETAUX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="MARKETAUX_API_KEY not set"):
+            MarketauxNewsProvider().get_articles("IONQ")

--- a/tests/unit/test_relevance.py
+++ b/tests/unit/test_relevance.py
@@ -94,3 +94,65 @@ class TestRelevanceClassifier:
         result = RelevanceClassifier().classify("IONQ", "IonQ", [])
         assert result == []
         mock_client.chat.completions.create.assert_not_called()
+
+    # ---- classify_stream() tests ----
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_stream_yields_tuples_with_correct_index(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response("yes")
+        articles = _make_articles(3)
+        results = list(RelevanceClassifier().classify_stream("IONQ", "IonQ", articles))
+        assert len(results) == 3
+        for i, (index, article, relevant) in enumerate(results):
+            assert index == i
+            assert article == articles[i]
+            assert relevant is True
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_stream_yes_true_no_false(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = [
+            _make_openai_response(r) for r in ["yes", "no", "yes"]
+        ]
+        articles = _make_articles(3)
+        results = list(RelevanceClassifier().classify_stream("IONQ", "IonQ", articles))
+        assert [r for _, _, r in results] == [True, False, True]
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_stream_api_error_yields_false_no_raise(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = Exception("API down")
+        articles = _make_articles(2)
+        results = list(RelevanceClassifier().classify_stream("IONQ", "IonQ", articles))
+        assert len(results) == 2
+        assert all(r is False for _, _, r in results)
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_stream_caps_at_max_articles(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response("yes")
+        articles = _make_articles(MAX_ARTICLES + 5)
+        results = list(RelevanceClassifier().classify_stream("IONQ", "IonQ", articles))
+        assert len(results) == MAX_ARTICLES + 5
+        assert mock_client.chat.completions.create.call_count == MAX_ARTICLES
+        assert all(r is False for _, _, r in results[MAX_ARTICLES:])
+        for expected_i, (index, _, _) in enumerate(results[MAX_ARTICLES:], start=MAX_ARTICLES):
+            assert index == expected_i
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_stream_empty_input_yields_nothing(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        results = list(RelevanceClassifier().classify_stream("IONQ", "IonQ", []))
+        assert results == []
+        mock_client.chat.completions.create.assert_not_called()

--- a/tests/unit/test_relevance.py
+++ b/tests/unit/test_relevance.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for the RelevanceClassifier.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qsf.nlp.relevance import MAX_ARTICLES, RelevanceClassifier
+
+
+def _make_openai_response(content: str):
+    """Build a minimal mock OpenAI chat completion response."""
+    choice = MagicMock()
+    choice.message.content = content
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+def _make_articles(n: int) -> list[dict]:
+    return [{"text": f"Article {i}", "date": "2026-02-10", "source": "news"} for i in range(n)]
+
+
+class TestRelevanceClassifier:
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_yes_returns_true(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response("yes")
+        result = RelevanceClassifier().classify("IONQ", "IonQ", [{"text": "IonQ Q4 results", "date": "2026-02-10", "source": "news"}])
+        assert result == [True]
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_no_returns_false(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response("no")
+        result = RelevanceClassifier().classify("IONQ", "IonQ", [{"text": "Unrelated article", "date": "2026-02-10", "source": "news"}])
+        assert result == [False]
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_case_insensitive(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response("Yes")
+        result = RelevanceClassifier().classify("IONQ", "IonQ", [{"text": "IonQ article", "date": "2026-02-10", "source": "news"}])
+        assert result == [True]
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_failed_api_call_returns_false_no_raise(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = Exception("API error")
+        result = RelevanceClassifier().classify("IONQ", "IonQ", [{"text": "Some article", "date": "2026-02-10", "source": "news"}])
+        assert result == [False]
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_returns_same_length_as_input(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response("yes")
+        articles = _make_articles(5)
+        result = RelevanceClassifier().classify("IONQ", "IonQ", articles)
+        assert len(result) == 5
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_caps_at_max_articles(self, mock_openai_cls, monkeypatch):
+        """Only MAX_ARTICLES API calls should be made; positions beyond cap default to False."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response("yes")
+
+        articles = _make_articles(MAX_ARTICLES + 5)
+        result = RelevanceClassifier().classify("IONQ", "IonQ", articles)
+
+        # Only MAX_ARTICLES API calls should have been made
+        assert mock_client.chat.completions.create.call_count == MAX_ARTICLES
+        # Result length matches input length
+        assert len(result) == MAX_ARTICLES + 5
+        # Positions beyond cap are False
+        assert all(r is False for r in result[MAX_ARTICLES:])
+
+    @patch("qsf.nlp.relevance.OpenAI")
+    def test_empty_input_returns_empty_list(self, mock_openai_cls, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        result = RelevanceClassifier().classify("IONQ", "IonQ", [])
+        assert result == []
+        mock_client.chat.completions.create.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `POST /diagnostics/news-comparison` and `GET /diagnostics/news-comparison/stream` endpoints to compare NewsAPI, Massive, AlphaVantage, and Marketaux for ticker relevance precision using GPT classification
- Implements SSE streaming so articles appear with ✓/✗ relevance labels as GPT classifies them — no waiting for the full run to complete
- Standalone `news_comparison.html` frontend: live article feed per provider, collapsible per-provider sections, best/worst precision highlighting, spinner per in-progress ticker
- Adds `RelevanceClassifier.classify_stream()` generator for per-article streaming alongside the existing batch `classify()` method
- 12 new tests (unit + integration) covering all new functionality

## Claude Code agent files (`.claude/`)

This PR also introduces `.claude/settings.json` and three agent definition files under `.claude/agents/`. These are Claude Code configuration files that set up a multi-agent workflow for this repo:

- **`.claude/settings.json`** — sets the default permission mode to `plan`, meaning Claude will always present a plan for approval before making any code changes
- **`.claude/agents/code-builder.md`** — defines a `code-builder` sub-agent scoped to Python implementation tasks (FastAPI, LangGraph, ingestion providers). Used when building new features or editing existing modules
- **`.claude/agents/code-reviewer.md`** — defines a `code-reviewer` sub-agent for read-only code review against a checklist (correctness, security, consistency, test coverage). Used before finalising changes or creating PRs
- **`.claude/agents/test-runner.md`** — defines a `test-runner` sub-agent (uses the lighter Haiku model) for running pytest and fixing failures after implementation

These files live in the repo so the agent setup is shared across the team and persists across sessions.

## Test plan
- [ ] Run tests: `.venv/bin/pytest tests/ -v` — 119 tests should pass
- [ ] Start server: `.venv/bin/python -m uvicorn qsf.api.main:app --reload`
- [ ] Open the frontend — either navigate to `file:///path/to/qsent/news_comparison.html` in your browser, or from the repo root run `open news_comparison.html`
- [ ] Enter `IONQ, FORM`, click Run — verify cards stream in progressively with article feed
- [ ] Verify providers with missing API keys show inline error rows without crashing the stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1056" height="697" alt="Screenshot at Apr 05 21-30-19" src="https://github.com/user-attachments/assets/6875fa3a-b36f-4dd9-888a-217a35276004" />
<img width="999" height="694" alt="Screenshot at Apr 05 21-30-39" src="https://github.com/user-attachments/assets/4fc298aa-bc82-49f7-a382-8b0799d4849e" />
