### PR TITLE
Port forecasting, features, and backtesting modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,39 @@ The best model is selected by Sharpe ratio. Results include accuracy, Sharpe, ma
 
 **How it connects to the sentiment pipeline:** The `/analyze` endpoint already outputs `news_sentiment` and `social_sentiment` per day — exactly what the forecasting pipeline expects. The forecasting pipeline fetches its own 2-year market data window via yfinance and uses sentiment as an overlay on top of technical indicators (RSI, volatility, moving averages, momentum).
 
-**Current status:** The module is implemented but not yet wired into the API. A `/forecast` endpoint is the planned next step.
+### Wiring it into the API
 
-**Optional dependency:** XGBoost models require an extra install:
-```bash
-pip install -e ".[forecasting-extra]"
+The existing `/analyze` output already contains everything the forecasting pipeline needs. The connection looks like this:
+
+```python
+from qsf.forecasting.pipeline import ForecastingPipeline
+import pandas as pd
+
+# Convert daily_data from /analyze output into a DataFrame
+sentiment_daily = pd.DataFrame([
+    {
+        "date": pd.to_datetime(item["date"]),
+        "news_sentiment": item["news_sentiment"],
+        "social_sentiment": item["social_sentiment"],
+    }
+    for item in result["daily_data"]
+]).set_index("date")
+
+# Run the forecasting pipeline
+forecaster = ForecastingPipeline(ticker="IONQ", period="2y")
+forecast = forecaster.run(sentiment_daily=sentiment_daily)
+
+# forecast["best_model"] contains direction prediction, Sharpe, drawdown, total return
 ```
+
+### What needs to change
+
+- **New `/forecast` endpoint** — separate from `/analyze` since it trains multiple models and is significantly slower
+- **Async or caching** — the forecasting pipeline can take 10–30 seconds; it should run async or cache results by ticker
+- **UI additions** — a new section on the frontend to display predicted direction, model confidence, Sharpe ratio, and max drawdown
+- **XGBoost** — optional but improves results; requires `pip install -e ".[forecasting-extra]"`
+
+**Current status:** The module is implemented but not yet wired into the API. A `/forecast` endpoint is the planned next step.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ Generated outputs and artifacts.
 
 ---
 
+## Forecasting Module
+
+The forecasting module (`src/qsf/forecasting/`) takes historical market data combined with the sentiment scores produced by the pipeline and trains classical ML models to predict next-day price movement. It uses a two-stage approach:
+
+- **Stage 1** — direction classification (up or down) using Logistic Regression, Random Forest, or XGBoost
+- **Stage 2** — magnitude regression (how much) using Ridge or XGBoost
+
+The best model is selected by Sharpe ratio. Results include accuracy, Sharpe, max drawdown, and total return from a simulated trading strategy.
+
+**How it connects to the sentiment pipeline:** The `/analyze` endpoint already outputs `news_sentiment` and `social_sentiment` per day — exactly what the forecasting pipeline expects. The forecasting pipeline fetches its own 2-year market data window via yfinance and uses sentiment as an overlay on top of technical indicators (RSI, volatility, moving averages, momentum).
+
+**Current status:** The module is implemented but not yet wired into the API. A `/forecast` endpoint is the planned next step.
+
+**Optional dependency:** XGBoost models require an extra install:
+```bash
+pip install -e ".[forecasting-extra]"
+```
+
+---
+
 ## Sentiment Chart Prototype
 
 A browser prototype is served directly by the API at `http://localhost:8000`. It renders three lines over time for any ticker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,15 @@ dependencies = [
     "httpx>=0.27",
     "authlib>=1.3",
     "python-jose[cryptography]>=3.3",
+    "numpy>=1.24",
+    "scipy>=1.10",
+    "scikit-learn>=1.3",
 ]
 
 [project.optional-dependencies]
+forecasting-extra = [
+    "xgboost>=2.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-mock>=3.14",

--- a/src/qsf/backtesting/__init__.py
+++ b/src/qsf/backtesting/__init__.py
@@ -1,0 +1,4 @@
+from qsf.backtesting.walk_forward import walk_forward_validate
+from qsf.backtesting.metrics import compute_risk_metrics, simulate_strategy
+
+__all__ = ["walk_forward_validate", "compute_risk_metrics", "simulate_strategy"]

--- a/src/qsf/backtesting/metrics.py
+++ b/src/qsf/backtesting/metrics.py
@@ -1,0 +1,100 @@
+"""
+Trading and risk metrics ported from the Phase 2 notebook.
+"""
+import numpy as np
+import pandas as pd
+
+ANNUALIZATION_FACTOR = 252.0
+
+
+def compute_risk_metrics(strategy_returns: np.ndarray) -> dict[str, float]:
+    """Compute comprehensive risk metrics from a strategy return series.
+
+    Parameters
+    ----------
+    strategy_returns : np.ndarray
+        Daily strategy returns (net of costs).
+
+    Returns
+    -------
+    dict with keys: total_return_pct, sharpe, sortino, max_drawdown_pct,
+    win_rate_pct, profit_factor, volatility_annual_pct.
+    """
+    equity = np.cumprod(1.0 + strategy_returns)
+    total_return = float((equity[-1] - 1.0) * 100)
+
+    mean_d = np.mean(strategy_returns)
+    std_d = np.std(strategy_returns, ddof=0)
+
+    sharpe = 0.0
+    if std_d > 0:
+        sharpe = float(
+            (mean_d * ANNUALIZATION_FACTOR) / (std_d * np.sqrt(ANNUALIZATION_FACTOR))
+        )
+
+    downside = strategy_returns[strategy_returns < 0]
+    downside_std = np.std(downside, ddof=0) if len(downside) > 0 else 0.0
+    sortino = 0.0
+    if downside_std > 0:
+        sortino = float(
+            (mean_d * ANNUALIZATION_FACTOR)
+            / (downside_std * np.sqrt(ANNUALIZATION_FACTOR))
+        )
+
+    cummax = np.maximum.accumulate(equity)
+    drawdowns = (equity - cummax) / cummax
+    max_dd = float(np.min(drawdowns) * 100) if len(drawdowns) > 0 else 0.0
+
+    wins = strategy_returns[strategy_returns > 0]
+    losses = strategy_returns[strategy_returns < 0]
+    win_rate = float(len(wins) / len(strategy_returns) * 100) if len(strategy_returns) > 0 else 0.0
+
+    gross_wins = float(np.sum(wins)) if len(wins) > 0 else 0.0
+    gross_losses = float(np.abs(np.sum(losses))) if len(losses) > 0 else 0.0
+    profit_factor = gross_wins / gross_losses if gross_losses > 0 else float("inf")
+
+    vol_annual = float(std_d * np.sqrt(ANNUALIZATION_FACTOR) * 100)
+
+    return {
+        "total_return_pct": total_return,
+        "sharpe": sharpe,
+        "sortino": sortino,
+        "max_drawdown_pct": max_dd,
+        "win_rate_pct": win_rate,
+        "profit_factor": profit_factor,
+        "volatility_annual_pct": vol_annual,
+    }
+
+
+def simulate_strategy(
+    actual_returns: np.ndarray,
+    predictions: np.ndarray,
+    cost_bps: float = 20.0,
+) -> tuple[np.ndarray, dict[str, float]]:
+    """Simulate a sign-based long/flat strategy with transaction costs.
+
+    Parameters
+    ----------
+    actual_returns : np.ndarray
+        Actual daily returns.
+    predictions : np.ndarray
+        Model predictions (positive = go long, else flat).
+    cost_bps : float
+        Round-trip transaction cost in basis points.
+
+    Returns
+    -------
+    tuple[np.ndarray, dict]
+        (strategy_returns, risk_metrics)
+    """
+    position = (predictions > 0).astype(float)
+    turnover = np.abs(np.diff(position, prepend=position[0]))
+    cost_per_side = (cost_bps / 2.0) / 10_000.0
+
+    lagged_pos = np.roll(position, 1)
+    lagged_pos[0] = 0.0
+
+    strategy_returns = lagged_pos * actual_returns - turnover * cost_per_side
+    metrics = compute_risk_metrics(strategy_returns)
+
+    return strategy_returns, metrics

--- a/src/qsf/backtesting/walk_forward.py
+++ b/src/qsf/backtesting/walk_forward.py
@@ -1,0 +1,137 @@
+"""
+Walk-forward validation framework from the Phase 2 notebook.
+
+Uses rolling windows to simulate live deployment: train on a window of
+historical data, predict the next period, roll forward, repeat.
+"""
+import logging
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+from qsf.backtesting.metrics import compute_risk_metrics
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TRAIN_WINDOW = 252  # ~1 year of trading days
+DEFAULT_TEST_WINDOW = 63    # ~1 quarter
+DEFAULT_STEP_SIZE = 21      # ~1 month
+
+
+def walk_forward_validate(
+    df: pd.DataFrame,
+    feature_cols: list[str],
+    target_col: str,
+    model_factory: Callable[[], Any],
+    train_window: int = DEFAULT_TRAIN_WINDOW,
+    test_window: int = DEFAULT_TEST_WINDOW,
+    step_size: int = DEFAULT_STEP_SIZE,
+    is_classifier: bool = False,
+) -> dict[str, Any]:
+    """Run walk-forward validation on a time-series dataset.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Full dataset with features and target.
+    feature_cols : list[str]
+        Feature column names.
+    target_col : str
+        Target column name.
+    model_factory : callable
+        Returns a fresh model instance with .fit() and .predict() methods.
+    train_window : int
+        Number of rows in each training window.
+    test_window : int
+        Number of rows in each test window.
+    step_size : int
+        Number of rows to step forward between folds.
+    is_classifier : bool
+        If True, binarize target for training.
+
+    Returns
+    -------
+    dict with keys: fold_results (list of per-fold dicts), all_predictions,
+    all_actuals, all_dates, aggregate_metrics.
+    """
+    n = len(df)
+    fold_results = []
+    all_predictions = []
+    all_actuals = []
+    all_dates = []
+
+    fold_idx = 0
+    start = 0
+
+    while start + train_window + test_window <= n:
+        train_end = start + train_window
+        test_end = min(train_end + test_window, n)
+
+        train_slice = df.iloc[start:train_end]
+        test_slice = df.iloc[train_end:test_end]
+
+        scaler = StandardScaler()
+        X_train = scaler.fit_transform(train_slice[feature_cols].values)
+        X_test = scaler.transform(test_slice[feature_cols].values)
+
+        y_train = train_slice[target_col].values
+        y_test = test_slice[target_col].values
+
+        if is_classifier:
+            y_train_fit = (y_train > 0).astype(int)
+        else:
+            y_train_fit = y_train
+
+        model = model_factory()
+        model.fit(X_train, y_train_fit)
+        preds = model.predict(X_test)
+
+        if is_classifier:
+            pred_returns = np.where(preds == 1, 1.0, -1.0)
+        else:
+            pred_returns = preds
+
+        dir_correct = np.sign(pred_returns) == np.sign(y_test)
+        dir_acc = float(np.mean(dir_correct))
+
+        fold_results.append({
+            "fold": fold_idx,
+            "train_start": str(train_slice.index[0].date()),
+            "train_end": str(train_slice.index[-1].date()),
+            "test_start": str(test_slice.index[0].date()),
+            "test_end": str(test_slice.index[-1].date()),
+            "test_size": len(test_slice),
+            "directional_accuracy": dir_acc,
+        })
+
+        all_predictions.extend(pred_returns.tolist())
+        all_actuals.extend(y_test.tolist())
+        all_dates.extend([str(d.date()) for d in test_slice.index])
+
+        fold_idx += 1
+        start += step_size
+
+    all_preds_arr = np.array(all_predictions)
+    all_actuals_arr = np.array(all_actuals)
+
+    aggregate = {}
+    if len(all_preds_arr) > 0:
+        dir_correct = np.sign(all_preds_arr) == np.sign(all_actuals_arr)
+        aggregate["directional_accuracy"] = float(np.mean(dir_correct))
+        aggregate["n_folds"] = fold_idx
+        aggregate["total_predictions"] = len(all_preds_arr)
+
+        risk = compute_risk_metrics(
+            np.where(all_preds_arr > 0, 1.0, 0.0) * all_actuals_arr
+        )
+        aggregate.update(risk)
+
+    return {
+        "fold_results": fold_results,
+        "all_predictions": all_predictions,
+        "all_actuals": all_actuals,
+        "all_dates": all_dates,
+        "aggregate_metrics": aggregate,
+    }

--- a/src/qsf/features/__init__.py
+++ b/src/qsf/features/__init__.py
@@ -1,0 +1,5 @@
+from qsf.features.engineering import engineer_features
+from qsf.features.targets import create_targets
+from qsf.features.preparation import prepare_data_bundle
+
+__all__ = ["engineer_features", "create_targets", "prepare_data_bundle"]

--- a/src/qsf/features/engineering.py
+++ b/src/qsf/features/engineering.py
@@ -1,0 +1,138 @@
+"""
+Feature engineering pipeline ported from Phase 2 forecasting notebook.
+
+Constructs technical indicators, cross-asset features, and macro transforms
+from market data. Applies the "Grand Shift" to enforce strict causality:
+features at row t use only data available at t-1.
+"""
+import logging
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+RSI_PERIOD = 14
+VOLATILITY_WINDOW = 20
+ROC_WINDOWS = [5, 10, 20]
+MA_WINDOWS = [5, 20, 50]
+FEATURE_SHIFT = 1
+
+EXCLUDE_FROM_GRAND_SHIFT = [
+    "target_ret_next",
+    "target_return",
+    "target_dir_next",
+    "Open",
+    "High",
+    "Low",
+    "Close",
+    "Volume",
+]
+
+
+def compute_rsi(price_series: pd.Series, period: int = RSI_PERIOD) -> pd.Series:
+    delta = price_series.diff()
+    gain = delta.where(delta > 0, 0)
+    loss = -delta.where(delta < 0, 0)
+    avg_gain = gain.rolling(window=period, min_periods=period // 2).mean()
+    avg_loss = loss.rolling(window=period, min_periods=period // 2).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    return 100 - (100 / (1 + rs))
+
+
+def engineer_features(
+    df: pd.DataFrame,
+    sentiment_daily: Optional[pd.DataFrame] = None,
+    proxy_columns: Optional[dict[str, str]] = None,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Build feature set from market data and optional sentiment scores.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Must contain at minimum 'Close', 'Volume' columns with a DatetimeIndex.
+    sentiment_daily : pd.DataFrame, optional
+        Daily sentiment with columns like 'news_sentiment', 'social_sentiment'.
+        Index should be dates matching df.
+    proxy_columns : dict, optional
+        Mapping of safe ticker name -> return column name already in df,
+        e.g. {"QTUM": "ret_qtum"}.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, list[str]]
+        (df with features + targets, list of feature column names)
+    """
+    df = df.copy()
+
+    # --- Returns ---
+    if "ret" in df.columns:
+        df["ret_ionq"] = df["ret"]
+    else:
+        df["ret_ionq"] = df["Close"].pct_change()
+
+    if proxy_columns:
+        for safe_ticker, ret_col in proxy_columns.items():
+            if ret_col in df.columns:
+                pass  # already present
+            elif safe_ticker in df.columns:
+                df[ret_col] = df[safe_ticker].pct_change()
+
+    # --- Technical indicators ---
+    df["ionq_vol_20"] = df["ret_ionq"].rolling(
+        window=VOLATILITY_WINDOW, min_periods=VOLATILITY_WINDOW // 2
+    ).std()
+
+    df["ionq_rsi_14"] = compute_rsi(df["Close"], period=RSI_PERIOD)
+
+    for window in ROC_WINDOWS:
+        df[f"ionq_roc_{window}"] = df["Close"].pct_change(periods=window)
+
+    for window in MA_WINDOWS:
+        df[f"ionq_ma_{window}"] = df["Close"].rolling(
+            window=window, min_periods=window // 2
+        ).mean()
+
+    df["ionq_dist_ma20"] = (df["Close"] - df["ionq_ma_20"]) / df["ionq_ma_20"]
+
+    # --- Cross-asset spreads ---
+    if proxy_columns:
+        for safe_ticker, ret_col in proxy_columns.items():
+            if ret_col in df.columns:
+                df[f"spread_ionq_{safe_ticker.lower()}"] = df["ret_ionq"] - df[ret_col]
+
+    # --- Macro transforms ---
+    for indicator in ["VIX", "US10Y", "US3M", "TERM_SPREAD"]:
+        if indicator in df.columns:
+            df[f"d{indicator}"] = df[indicator].diff()
+
+    if "VIX" in df.columns:
+        df["VIX_squared"] = df["VIX"] ** 2
+
+    # --- Sentiment features (from QSent pipeline) ---
+    if sentiment_daily is not None:
+        for col in sentiment_daily.columns:
+            if col not in df.columns:
+                df[col] = sentiment_daily[col].reindex(df.index)
+        # Lagged sentiment to avoid look-ahead
+        for col in sentiment_daily.columns:
+            lag_col = f"{col}_lag1"
+            if lag_col not in EXCLUDE_FROM_GRAND_SHIFT:
+                EXCLUDE_FROM_GRAND_SHIFT.append(lag_col)
+            df[lag_col] = df[col].shift(1)
+
+    # --- Identify feature columns ---
+    feature_cols = [
+        col for col in df.columns
+        if col not in EXCLUDE_FROM_GRAND_SHIFT
+        and not col.startswith("target_")
+        and col not in ["Open", "High", "Low", "Close", "Volume", "Adj_Close", "ret"]
+    ]
+
+    # --- Grand Shift: enforce causality ---
+    logger.info("Applying Grand Shift to %d feature columns", len(feature_cols))
+    for col in feature_cols:
+        df[col] = df[col].shift(FEATURE_SHIFT)
+
+    return df, feature_cols

--- a/src/qsf/features/preparation.py
+++ b/src/qsf/features/preparation.py
@@ -1,0 +1,113 @@
+"""
+Data preparation: chronological splits, scaling, and data bundle assembly.
+
+All scaling is fit on training data only to prevent information leakage.
+"""
+import logging
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TRAIN_FRAC = 0.60
+DEFAULT_VAL_FRAC = 0.20
+DEFAULT_TEST_FRAC = 0.20
+
+MAX_NAN_FRACTION = 0.10
+
+EXCLUDE_OHLCV = {"Open", "High", "Low", "Close", "Volume", "Adj_Close", "Adj Close", "ret"}
+
+
+def _select_features(
+    df: pd.DataFrame,
+    feature_cols: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Identify feature and target columns."""
+    target_cols = [c for c in df.columns if c.startswith("target_")]
+    if feature_cols is None:
+        excluded = set(target_cols) | EXCLUDE_OHLCV
+        feature_cols = [c for c in df.columns if c not in excluded]
+    return feature_cols, target_cols
+
+
+def prepare_data_bundle(
+    df: pd.DataFrame,
+    feature_cols: list[str] | None = None,
+    primary_target: str = "target_return",
+    train_frac: float = DEFAULT_TRAIN_FRAC,
+    val_frac: float = DEFAULT_VAL_FRAC,
+    test_frac: float = DEFAULT_TEST_FRAC,
+) -> dict[str, Any]:
+    """Prepare train/val/test splits with leak-free scaling.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Feature-engineered DataFrame with targets.
+    feature_cols : list[str] or None
+        If None, auto-detected by excluding targets and raw OHLCV.
+    primary_target : str
+        Regression target column name.
+    train_frac, val_frac, test_frac : float
+        Split fractions (must sum to 1.0).
+
+    Returns
+    -------
+    dict
+        Keys: X_train, X_val, X_test (scaled numpy arrays),
+        y_train, y_val, y_test (unscaled numpy arrays),
+        train_df, val_df, test_df (DataFrames),
+        feature_cols, target_cols, primary_target, scaler.
+    """
+    feature_cols, target_cols = _select_features(df, feature_cols)
+
+    # Clean NaNs
+    nan_per_row = df[feature_cols].isna().sum(axis=1)
+    max_nan = int(len(feature_cols) * MAX_NAN_FRACTION)
+    df_clean = df[nan_per_row <= max_nan].dropna(subset=[primary_target]).copy()
+
+    remaining_nans = df_clean[feature_cols].isna()
+    if remaining_nans.any().any():
+        df_clean[feature_cols] = df_clean[feature_cols].fillna(0.0)
+
+    logger.info(
+        "Data after cleaning: %d rows, %d features", len(df_clean), len(feature_cols)
+    )
+
+    # Chronological splits
+    n = len(df_clean)
+    train_end = int(n * train_frac)
+    val_end = int(n * (train_frac + val_frac))
+
+    train_df = df_clean.iloc[:train_end].copy()
+    val_df = df_clean.iloc[train_end:val_end].copy()
+    test_df = df_clean.iloc[val_end:].copy()
+
+    # Fit scaler on train only
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(train_df[feature_cols].values)
+    X_val = scaler.transform(val_df[feature_cols].values)
+    X_test = scaler.transform(test_df[feature_cols].values)
+
+    y_train = train_df[primary_target].values
+    y_val = val_df[primary_target].values
+    y_test = test_df[primary_target].values
+
+    return {
+        "X_train": X_train,
+        "X_val": X_val,
+        "X_test": X_test,
+        "y_train": y_train,
+        "y_val": y_val,
+        "y_test": y_test,
+        "train_df": train_df,
+        "val_df": val_df,
+        "test_df": test_df,
+        "feature_cols": feature_cols,
+        "target_cols": target_cols,
+        "primary_target": primary_target,
+        "scaler": scaler,
+    }

--- a/src/qsf/features/targets.py
+++ b/src/qsf/features/targets.py
@@ -1,0 +1,47 @@
+"""
+Target variable creation for forecasting models.
+
+Creates regression (next-day return) and classification (direction) targets.
+Optionally creates a ternary target with a dead zone around zero.
+"""
+import numpy as np
+import pandas as pd
+
+DEAD_ZONE_STD_MULTIPLIER = 0.5
+
+
+def create_targets(
+    df: pd.DataFrame,
+    return_col: str = "ret_ionq",
+    dead_zone_multiplier: float = DEAD_ZONE_STD_MULTIPLIER,
+) -> tuple[pd.DataFrame, float]:
+    """Create prediction targets from return series.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Must contain ``return_col``.
+    return_col : str
+        Column with daily returns.
+    dead_zone_multiplier : float
+        Fraction of return std to use as dead-zone threshold for ternary target.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, float]
+        (df with target columns added, dead-zone threshold tau)
+    """
+    df = df.copy()
+
+    df["target_ret_next"] = df[return_col].shift(-1)
+    df["target_return"] = df["target_ret_next"]
+    df["target_dir_next"] = (df["target_ret_next"] > 0).astype(int)
+
+    tau = df[return_col].std() * dead_zone_multiplier
+    df["target_ternary"] = 0
+    df.loc[df["target_ret_next"] > tau, "target_ternary"] = 1
+    df.loc[df["target_ret_next"] < -tau, "target_ternary"] = -1
+
+    df = df.dropna(subset=["target_ret_next"])
+
+    return df, tau

--- a/src/qsf/forecasting/__init__.py
+++ b/src/qsf/forecasting/__init__.py
@@ -1,0 +1,17 @@
+from qsf.forecasting.models import (
+    LogisticRegressionModel,
+    RandomForestModel,
+    XGBoostClassifierModel,
+    RidgeRegressionModel,
+    XGBoostRegressorModel,
+)
+from qsf.forecasting.pipeline import ForecastingPipeline
+
+__all__ = [
+    "LogisticRegressionModel",
+    "RandomForestModel",
+    "XGBoostClassifierModel",
+    "RidgeRegressionModel",
+    "XGBoostRegressorModel",
+    "ForecastingPipeline",
+]

--- a/src/qsf/forecasting/models.py
+++ b/src/qsf/forecasting/models.py
@@ -1,0 +1,212 @@
+"""
+Classical ML forecasting models ported from the Phase 2 notebook.
+
+Two-stage prediction strategy:
+  Stage 1 — Direction classification (up/down)
+  Stage 2 — Magnitude regression (predicted return size)
+
+Models are kept simple and scikit-learn-based for this first integration pass.
+Deep learning models (LSTM, GRU, NBEATS, TFT) are deferred to a future phase.
+"""
+import logging
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression, Ridge
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+
+logger = logging.getLogger(__name__)
+
+
+class Classifier(Protocol):
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None: ...
+    def predict(self, X: np.ndarray) -> np.ndarray: ...
+    def predict_proba(self, X: np.ndarray) -> np.ndarray: ...
+
+
+class Regressor(Protocol):
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None: ...
+    def predict(self, X: np.ndarray) -> np.ndarray: ...
+
+
+@dataclass
+class ModelResult:
+    name: str
+    model_type: str  # "classifier" or "regressor"
+    predictions: np.ndarray
+    train_predictions: np.ndarray | None = None
+
+
+# ---------------------------------------------------------------------------
+# Classifiers (Stage 1: direction prediction)
+# ---------------------------------------------------------------------------
+
+class LogisticRegressionModel:
+    name = "LogisticRegression"
+
+    def __init__(self, max_iter: int = 1000, C: float = 1.0):
+        self._model = LogisticRegression(max_iter=max_iter, C=C, solver="lbfgs")
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self._model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict(X)
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict_proba(X)
+
+    def run(
+        self, X_train: np.ndarray, y_train: np.ndarray, X_test: np.ndarray
+    ) -> ModelResult:
+        self.fit(X_train, y_train)
+        return ModelResult(
+            name=self.name,
+            model_type="classifier",
+            predictions=self.predict(X_test),
+            train_predictions=self.predict(X_train),
+        )
+
+
+class RandomForestModel:
+    name = "RandomForest"
+
+    def __init__(self, n_estimators: int = 200, max_depth: int | None = 10, random_state: int = 42):
+        self._model = RandomForestClassifier(
+            n_estimators=n_estimators, max_depth=max_depth, random_state=random_state
+        )
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self._model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict(X)
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict_proba(X)
+
+    def feature_importances(self) -> np.ndarray:
+        return self._model.feature_importances_
+
+    def run(
+        self, X_train: np.ndarray, y_train: np.ndarray, X_test: np.ndarray
+    ) -> ModelResult:
+        self.fit(X_train, y_train)
+        return ModelResult(
+            name=self.name,
+            model_type="classifier",
+            predictions=self.predict(X_test),
+            train_predictions=self.predict(X_train),
+        )
+
+
+class XGBoostClassifierModel:
+    name = "XGBoost_Classifier"
+
+    def __init__(
+        self,
+        n_estimators: int = 200,
+        max_depth: int = 6,
+        learning_rate: float = 0.1,
+        random_state: int = 42,
+    ):
+        try:
+            from xgboost import XGBClassifier
+        except ImportError as e:
+            raise ImportError("xgboost is required for XGBoostClassifierModel") from e
+        self._model = XGBClassifier(
+            n_estimators=n_estimators,
+            max_depth=max_depth,
+            learning_rate=learning_rate,
+            random_state=random_state,
+            use_label_encoder=False,
+            eval_metric="logloss",
+        )
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self._model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict(X)
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict_proba(X)
+
+    def run(
+        self, X_train: np.ndarray, y_train: np.ndarray, X_test: np.ndarray
+    ) -> ModelResult:
+        self.fit(X_train, y_train)
+        return ModelResult(
+            name=self.name,
+            model_type="classifier",
+            predictions=self.predict(X_test),
+            train_predictions=self.predict(X_train),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regressors (Stage 2: magnitude prediction)
+# ---------------------------------------------------------------------------
+
+class RidgeRegressionModel:
+    name = "Ridge"
+
+    def __init__(self, alpha: float = 1.0):
+        self._model = Ridge(alpha=alpha)
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self._model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict(X)
+
+    def run(
+        self, X_train: np.ndarray, y_train: np.ndarray, X_test: np.ndarray
+    ) -> ModelResult:
+        self.fit(X_train, y_train)
+        return ModelResult(
+            name=self.name,
+            model_type="regressor",
+            predictions=self.predict(X_test),
+            train_predictions=self.predict(X_train),
+        )
+
+
+class XGBoostRegressorModel:
+    name = "XGBoost_Regressor"
+
+    def __init__(
+        self,
+        n_estimators: int = 200,
+        max_depth: int = 6,
+        learning_rate: float = 0.1,
+        random_state: int = 42,
+    ):
+        try:
+            from xgboost import XGBRegressor
+        except ImportError as e:
+            raise ImportError("xgboost is required for XGBoostRegressorModel") from e
+        self._model = XGBRegressor(
+            n_estimators=n_estimators,
+            max_depth=max_depth,
+            learning_rate=learning_rate,
+            random_state=random_state,
+        )
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self._model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict(X)
+
+    def run(
+        self, X_train: np.ndarray, y_train: np.ndarray, X_test: np.ndarray
+    ) -> ModelResult:
+        self.fit(X_train, y_train)
+        return ModelResult(
+            name=self.name,
+            model_type="regressor",
+            predictions=self.predict(X_test),
+            train_predictions=self.predict(X_train),
+        )

--- a/src/qsf/forecasting/pipeline.py
+++ b/src/qsf/forecasting/pipeline.py
@@ -1,0 +1,225 @@
+"""
+End-to-end forecasting pipeline.
+
+Combines the QSent sentiment pipeline output with the Phase 2 feature
+engineering and classical ML models to produce price movement forecasts.
+"""
+import logging
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+
+from qsf.features.engineering import engineer_features
+from qsf.features.targets import create_targets
+from qsf.features.preparation import prepare_data_bundle
+from qsf.forecasting.models import (
+    LogisticRegressionModel,
+    RandomForestModel,
+    RidgeRegressionModel,
+    ModelResult,
+)
+
+logger = logging.getLogger(__name__)
+
+ANNUALIZATION_FACTOR = 252.0
+
+
+def _compute_metrics(
+    y_true: np.ndarray, predictions: np.ndarray, model_type: str
+) -> dict[str, float]:
+    """Compute evaluation metrics for a model's predictions."""
+    metrics: dict[str, float] = {}
+
+    if model_type == "classifier":
+        metrics["accuracy"] = float(np.mean(y_true == predictions))
+        direction_true = (y_true > 0).astype(int) if y_true.dtype != int else y_true
+        metrics["directional_accuracy"] = float(np.mean(direction_true == predictions))
+    else:
+        residuals = y_true - predictions
+        metrics["rmse"] = float(np.sqrt(np.mean(residuals**2)))
+        metrics["mae"] = float(np.mean(np.abs(residuals)))
+        ss_res = np.sum(residuals**2)
+        ss_tot = np.sum((y_true - np.mean(y_true)) ** 2)
+        metrics["r2"] = float(1 - ss_res / ss_tot) if ss_tot > 0 else 0.0
+        dir_correct = np.sign(predictions) == np.sign(y_true)
+        metrics["directional_accuracy"] = float(np.mean(dir_correct))
+
+    return metrics
+
+
+def _compute_trading_metrics(
+    returns: np.ndarray,
+    predictions: np.ndarray,
+    cost_bps: float = 20.0,
+) -> dict[str, float]:
+    """Simulate a sign-based strategy and compute trading metrics."""
+    position = (predictions > 0).astype(float)
+    turnover = np.abs(np.diff(position, prepend=position[0]))
+    cost_per_side = (cost_bps / 2.0) / 10_000.0
+    lagged_pos = np.roll(position, 1)
+    lagged_pos[0] = 0.0
+
+    strategy_returns = lagged_pos * returns - turnover * cost_per_side
+    equity = np.cumprod(1.0 + strategy_returns)
+
+    mean_daily = np.mean(strategy_returns)
+    std_daily = np.std(strategy_returns, ddof=0)
+    sharpe = 0.0
+    if std_daily > 0:
+        sharpe = float(
+            (mean_daily * ANNUALIZATION_FACTOR)
+            / (std_daily * np.sqrt(ANNUALIZATION_FACTOR))
+        )
+
+    cummax = np.maximum.accumulate(equity)
+    drawdowns = (equity - cummax) / cummax
+    max_drawdown = float(np.min(drawdowns)) if len(drawdowns) > 0 else 0.0
+
+    return {
+        "total_return_pct": float((equity[-1] - 1.0) * 100),
+        "sharpe": sharpe,
+        "max_drawdown_pct": float(max_drawdown * 100),
+        "trade_fraction_pct": float(np.mean(position) * 100),
+    }
+
+
+class ForecastingPipeline:
+    """Orchestrates feature engineering, model training, and evaluation."""
+
+    def __init__(
+        self,
+        ticker: str = "IONQ",
+        period: str = "2y",
+        cost_bps: float = 20.0,
+    ):
+        self.ticker = ticker
+        self.period = period
+        self.cost_bps = cost_bps
+
+    def run(
+        self,
+        sentiment_daily: pd.DataFrame | None = None,
+    ) -> dict[str, Any]:
+        """Execute the full forecasting pipeline.
+
+        Parameters
+        ----------
+        sentiment_daily : pd.DataFrame, optional
+            Daily sentiment scores from the QSent sentiment pipeline.
+            Expected columns: news_sentiment, social_sentiment.
+
+        Returns
+        -------
+        dict
+            Pipeline results including model comparisons and best forecast.
+        """
+        # 1. Fetch market data
+        logger.info("[%s] Fetching market data (%s)", self.ticker, self.period)
+        hist = yf.Ticker(self.ticker).history(period=self.period)
+        if hist.empty:
+            return {"error": f"No market data for {self.ticker}"}
+        hist.index = hist.index.tz_localize(None)
+
+        # 2. Feature engineering
+        logger.info("[%s] Engineering features", self.ticker)
+        df_features, feature_cols = engineer_features(
+            hist, sentiment_daily=sentiment_daily
+        )
+
+        # 3. Create targets
+        df_targets, tau = create_targets(df_features)
+
+        # 4. Prepare data bundle
+        bundle = prepare_data_bundle(
+            df_targets, feature_cols=feature_cols, primary_target="target_return"
+        )
+
+        X_train = bundle["X_train"]
+        y_train = bundle["y_train"]
+        X_test = bundle["X_test"]
+        y_test = bundle["y_test"]
+        X_val = bundle["X_val"]
+        y_val = bundle["y_val"]
+
+        # Binary direction targets for classifiers
+        y_train_dir = (y_train > 0).astype(int)
+        y_test_dir = (y_test > 0).astype(int)
+        y_val_dir = (y_val > 0).astype(int)
+
+        # 5. Train models
+        logger.info("[%s] Training models", self.ticker)
+        classifiers = [
+            LogisticRegressionModel(),
+            RandomForestModel(),
+        ]
+        regressors = [
+            RidgeRegressionModel(),
+        ]
+
+        # Try to add XGBoost if available
+        try:
+            from qsf.forecasting.models import (
+                XGBoostClassifierModel,
+                XGBoostRegressorModel,
+            )
+            classifiers.append(XGBoostClassifierModel())
+            regressors.append(XGBoostRegressorModel())
+        except ImportError:
+            logger.info("xgboost not available, skipping XGBoost models")
+
+        model_results: list[dict] = []
+
+        for model in classifiers:
+            result = model.run(X_train, y_train_dir, X_test)
+            metrics = _compute_metrics(y_test_dir, result.predictions, "classifier")
+
+            # Trading metrics: convert classifier predictions to return-signed
+            pred_returns = np.where(result.predictions == 1, 1.0, -1.0)
+            trading = _compute_trading_metrics(y_test, pred_returns, self.cost_bps)
+
+            model_results.append({
+                "name": result.name,
+                "type": "classifier",
+                "metrics": metrics,
+                "trading": trading,
+            })
+
+        for model in regressors:
+            result = model.run(X_train, y_train, X_test)
+            metrics = _compute_metrics(y_test, result.predictions, "regressor")
+            trading = _compute_trading_metrics(
+                y_test, result.predictions, self.cost_bps
+            )
+
+            model_results.append({
+                "name": result.name,
+                "type": "regressor",
+                "metrics": metrics,
+                "trading": trading,
+            })
+
+        # 6. Select best model by Sharpe ratio
+        best = max(model_results, key=lambda r: r["trading"]["sharpe"])
+
+        return {
+            "ticker": self.ticker,
+            "last_updated": datetime.now().isoformat(),
+            "data_points": len(hist),
+            "train_samples": len(bundle["train_df"]),
+            "val_samples": len(bundle["val_df"]),
+            "test_samples": len(bundle["test_df"]),
+            "n_features": len(feature_cols),
+            "feature_names": feature_cols,
+            "dead_zone_tau": float(tau),
+            "models": model_results,
+            "best_model": {
+                "name": best["name"],
+                "sharpe": best["trading"]["sharpe"],
+                "directional_accuracy": best["metrics"]["directional_accuracy"],
+                "total_return_pct": best["trading"]["total_return_pct"],
+                "max_drawdown_pct": best["trading"]["max_drawdown_pct"],
+            },
+        }


### PR DESCRIPTION
## What the forecasting module does

Takes historical market data combined with the sentiment scores already produced by the pipeline, then trains classical ML models (Logistic Regression, Random Forest, Ridge, optionally XGBoost) to predict next-day price movement. It uses a two-stage approach:
- Stage 1: predict direction (up or down)
- Stage 2: predict magnitude (how much)

It picks the best model by Sharpe ratio and returns full trading simulation metrics — accuracy, Sharpe, max drawdown, total return.

The existing `/analyze` endpoint already outputs `news_sentiment` and `social_sentiment` per day — exactly what the forecasting pipeline expects as input. The forecasting pipeline fetches its own 2-year market data window via yfinance and uses sentiment as an overlay on top of technical indicators.

## Summary

Ports the forecasting module from the `master` branch into main cleanly, without touching auth, API, or test changes that only exist on main.

- `src/qsf/forecasting/` — two-stage ML prediction: LogisticRegression, RandomForest, Ridge for direction + magnitude; XGBoost available as an optional extra
- `src/qsf/features/` — feature engineering from sentiment + market data, target creation, data preparation
- `src/qsf/backtesting/` — walk-forward evaluation and performance metrics
- `pyproject.toml` — added `numpy`, `scipy`, `scikit-learn` as core deps; `xgboost` as `forecasting-extra` optional

**Not yet wired into the API** — a `/forecast` endpoint would be the next step.

**What was intentionally NOT ported from master:**
- `index.html` — master has the old pre-auth version; main's version is correct
- `src/qsf/api/main.py` — master has no auth; kept main's version
- Test files — master has older versions without auth tests
- `.env.example`, `README.md`, `ci.yml` — kept main's updated versions

## Test plan

- [ ] `pytest tests/unit/ tests/integration/` — all 135 tests pass (verified locally)
- [ ] Start server and confirm app loads and auth still works
- [ ] `pip install -e ".[forecasting-extra]"` if XGBoost models are needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)