### PR TITLE
Add structured logging and Langfuse tracing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,14 @@ OPENAI_API_KEY=your_openai_api_key
 MASSIVE_API_KEY=your_massive_api_key
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_api_key
 MARKETAUX_API_KEY=your_marketaux_api_key
+
+# Observability — Langfuse tracing
+# Local Docker: run `docker compose -f docker-compose.langfuse.yml up -d`
+# Cloud: set LANGFUSE_HOST=https://cloud.langfuse.com and use keys from langfuse.com
+LANGFUSE_PUBLIC_KEY=pk-lf-local
+LANGFUSE_SECRET_KEY=sk-lf-local
+LANGFUSE_HOST=http://localhost:3000
+
+# Logging format: leave unset for colored console output, set to "json" for structured JSON
+# LOG_FORMAT=json
+# LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -208,6 +208,52 @@ No build step required — Chart.js is loaded from CDN.
 
 ---
 
+## Observability
+
+Every `/analyze` request produces two correlated records:
+
+**Structured logs (stdout)**
+Every log line carries a `trace_id` and `user_id` (Google's opaque `sub`, never email). In development, logs are pretty-printed. Set `LOG_FORMAT=json` for machine-readable output.
+
+```
+2026-05-18T14:32:01Z [info] request.received trace_id=d9a04fcb user_id=116234567890 method=POST path=/analyze
+2026-05-18T14:32:15Z [info] request.completed trace_id=d9a04fcb status=200 duration_ms=14200
+```
+
+Query by trace ID: `cat logs/app.log | jq 'select(.trace_id == "d9a04fcb")'`
+
+The `X-Trace-ID` header on every response contains the trace ID.
+
+**Langfuse trace UI**
+
+Langfuse records a full agentic trace per request: five pipeline node spans, child spans per external API call (NewsAPI, Reddit, yfinance), and a generation entry per FinBERT call.
+
+Start Langfuse locally (requires Docker):
+
+```bash
+docker compose -f docker-compose.langfuse.yml up -d
+```
+
+Then open http://localhost:3000, sign up, create a project, and copy the API keys into `.env`:
+
+```
+LANGFUSE_PUBLIC_KEY=<your public key>
+LANGFUSE_SECRET_KEY=<your secret key>
+LANGFUSE_HOST=http://localhost:3000
+```
+
+Restart the FastAPI server — traces will appear in the UI within seconds of each request.
+
+If `LANGFUSE_PUBLIC_KEY` is not set, tracing is silently disabled and the pipeline runs normally.
+
+**Tracing a specific user**
+
+Ask the user to open `http://localhost:8000/auth/me` — it returns their `google_sub` (an opaque permanent ID, not their email). Search Langfuse or grep logs by that value.
+
+See [ADR 006](docs/decisions/006-observability-structlog-langfuse.md) for the full rationale.
+
+---
+
 ## Authentication
 
 The app uses **Google SSO**. All API endpoints (except `/health`) require a valid session.
@@ -272,6 +318,11 @@ REDDIT_CLIENT_ID=
 REDDIT_CLIENT_SECRET=
 REDDIT_USER_AGENT=qsent/0.1
 HUGGINGFACE_API_KEY=
+
+# Observability (optional — pipeline runs without these)
+LANGFUSE_PUBLIC_KEY=         # from Langfuse project settings
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=http://localhost:3000
 ```
 
 To get `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`, create an OAuth 2.0 client in [Google Cloud Console](https://console.cloud.google.com) under APIs & Services → Credentials. Set the authorized redirect URI to `http://localhost:8000/auth/callback`.

--- a/docker-compose.langfuse.yml
+++ b/docker-compose.langfuse.yml
@@ -1,0 +1,35 @@
+services:
+  langfuse:
+    image: langfuse/langfuse:2
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse@db:5432/langfuse
+      NEXTAUTH_SECRET: vHGKxqy9bnCFunnQQZcKnH3EIYt93phL2g5y6jrBpzg=
+      SALT: kuZekaF3pafoNSZwVk203lMksNKHkttdh2k1nofaYxc=
+      NEXTAUTH_URL: http://localhost:3000
+      LANGFUSE_INIT_ORG_ID: qsent
+      LANGFUSE_INIT_PROJECT_ID: qsent
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: pk-lf-local
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: sk-lf-local
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse_db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  langfuse_db:

--- a/docs/decisions/006-observability-structlog-langfuse.md
+++ b/docs/decisions/006-observability-structlog-langfuse.md
@@ -1,0 +1,70 @@
+# ADR 006: Structured Logging with structlog and Agentic Tracing with Langfuse
+
+**Date:** 2026-05-18
+**Status:** Accepted
+
+## Context
+
+The pipeline runs five LangGraph nodes per `/analyze` request, each making external API calls to yfinance, NewsAPI, Reddit, and HuggingFace. Before this change, logs were unstructured stdlib output with no correlation IDs. There was no way to answer "what happened when user X analyzed IONQ at 2pm" without grepping raw stdout, and no visibility into which pipeline node failed or how long each external call took.
+
+Two categories of tooling were needed:
+
+1. **Request/response logging** — a structured record of every HTTP request with enough context to reconstruct what happened
+2. **Agentic tracing** — a UI showing each pipeline node's inputs, outputs, and child spans (analogous to LangSmith or Splunk for agentic workflows)
+
+A key constraint: **no PII in logs**. Email addresses must never appear in log output. Google's OAuth `sub` field (a permanent, opaque numeric ID like `"116234567890"`) is the right identifier — it can be looked up against the OAuth provider if needed for incident response, without storing PII at rest in logs.
+
+## Decision
+
+### structlog for structured logging
+
+Replace stdlib `logging.basicConfig` with [structlog](https://www.structlog.org/). structlog's `contextvars` integration injects per-request context (`trace_id`, `user_id`) into every log line automatically — no manual threading through function signatures.
+
+`TraceMiddleware` in `main.py` generates a `uuid4().hex` trace ID per request, binds it to structlog's contextvars, and sets it as the `X-Trace-ID` response header. Every log line emitted anywhere in the stack (including third-party libraries via `ProcessorFormatter`) carries that ID.
+
+`LOG_FORMAT=json` switches to machine-readable output for production. Default is the pretty console renderer.
+
+### Langfuse v2 (self-hosted) for agentic tracing
+
+[Langfuse](https://langfuse.com) is an open-source LangSmith equivalent. It persists traces to Postgres, provides a filterable web UI, and supports spans and generations natively.
+
+The v2 server is pinned specifically because v3+ requires ClickHouse as a separate analytics store, which adds significant infrastructure overhead for local development. The SDK is pinned to `langfuse>=2.0,<3.0` accordingly.
+
+Each `/analyze` request creates a Langfuse trace keyed by the same `trace_id` used in structured logs, so a single ID links stdout logs to the Langfuse UI. The five pipeline nodes each create a child span. External API calls (yfinance, NewsAPI, Reddit searches) create grandchild spans. Each FinBERT call creates a `generation` entry.
+
+`user_id` in Langfuse traces is always the Google `sub` — never email.
+
+### Google `sub` as the user identifier
+
+The JWT previously stored email in both `sub` and the payload. The OAuth `sub` (Google's permanent opaque user ID) was discarded. This change captures it at the OAuth callback, stores it in the JWT payload as `google_sub`, and uses it everywhere in observability output.
+
+To trace a specific user's activity: ask them to open `/auth/me` in their browser — it returns their own `google_sub`. Search Langfuse or grep logs by that value.
+
+## Alternatives Considered
+
+**LangSmith** — Free tier (5K traces/month) exists but data leaves the machine and the vendor is Anthropic's competitor LangChain. Rejected in favor of a self-hosted option.
+
+**Langfuse Cloud** — Available and free up to 50K observations/month. Chosen not to use for initial setup to keep all data local. Switching is a three-env-var change with no code modifications.
+
+**Langfuse v3/v4** — Requires ClickHouse. Tested and rejected; the server crashes immediately without it. v2 covers all needed functionality (spans, generations, user/session filtering) with only Postgres.
+
+**Phoenix (Arize)** — Excellent notebook-level debugging tool but in-memory by default. Does not persist traces across restarts. Better suited to offline evaluation than production request tracing.
+
+**OpenTelemetry directly** — Would work but requires more plumbing and a separate collector. Langfuse v2 provides the right abstraction level without OTEL complexity.
+
+**Logging email** — Rejected. Email is PII. Google's `sub` provides the same traceability for incident response without creating a PII liability in log storage.
+
+## Consequences
+
+**Improvements:**
+- Every log line carries `trace_id` and `user_id` — requests are fully reconstructable from stdout
+- Langfuse UI shows the full chain: request → LangGraph node → external API call → result, with durations
+- Failed FinBERT calls surface individually in the trace with the input text and error status
+- `X-Trace-ID` response header lets clients (or support staff) reference a specific request
+- No PII in any log output
+
+**Operational notes:**
+- Langfuse requires Docker to run locally (`docker compose -f docker-compose.langfuse.yml up -d`)
+- If `LANGFUSE_PUBLIC_KEY` is not set, tracing is silently disabled — the pipeline runs normally without it
+- `langfuse.flush()` is called after each pipeline invocation to ensure traces are sent before the HTTP response returns
+- Switching to Langfuse Cloud: change `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` in `.env`. No code changes required.

--- a/docs/decisions/007-google-sso-authentication.md
+++ b/docs/decisions/007-google-sso-authentication.md
@@ -1,0 +1,63 @@
+# ADR 007: Google SSO via OAuth 2.0 Authorization Code Flow
+
+**Date:** 2026-05-18
+**Status:** Accepted
+
+## Context
+
+The app needed authentication before exposing the `/analyze` endpoint publicly. Three broad approaches were on the table: hand-roll username/password auth, use a third-party auth service (Auth0, Clerk), or delegate entirely to an existing identity provider via OAuth/OIDC.
+
+The user base is a small internal team, all of whom already have Google accounts. There is no requirement to support non-Google sign-in.
+
+## Decision
+
+Implement Google SSO using the OAuth 2.0 Authorization Code flow with PKCE-equivalent CSRF protection (state parameter). Sessions are stored in an HttpOnly, SameSite=Lax JWT cookie issued by the app, not in a server-side session store.
+
+The implementation is in `src/qsf/api/auth.py` and uses:
+- **Authlib** for the OAuth 2.0 client (handles authorization URL construction, token exchange)
+- **python-jose** for JWT signing and verification
+- **Google's `/userinfo` endpoint** to retrieve email, display name, profile picture, and `sub` after token exchange
+
+The flow:
+1. `GET /auth/login` — generates a random `state` token, stores it in a short-lived HttpOnly cookie, redirects to Google's authorization URL
+2. Google redirects back to `GET /auth/callback` with an authorization code and the `state` value
+3. The callback validates the `state` against the cookie (CSRF protection), exchanges the code for an access token, fetches userinfo, and issues a signed JWT session cookie (`qsent_session`)
+4. All subsequent requests authenticate by verifying the JWT cookie in `get_current_user()`
+
+Session cookies are `httponly=True` (no JS access), `samesite="lax"` (CSRF mitigation), and `secure=True` in production (set via `SECURE_COOKIES=true`). Sessions expire after 8 hours.
+
+The Google-issued `sub` field is stored in the JWT alongside email, so it is available for PII-free logging and tracing (see ADR 006).
+
+A `TEST_MODE=true` bypass route is registered only when that env var is set, and issues a session with a fixed fake user. It is never reachable in production.
+
+## Alternatives Considered
+
+**Hand-rolled username/password auth**
+
+Rejected. Building password auth correctly requires: secure password hashing (bcrypt/argon2), email verification flows, password reset flows, brute-force rate limiting, breach detection, and ongoing maintenance as attack patterns evolve. Each of these is a meaningful surface area for error. Teams that hand-roll this regularly get it wrong in ways that are only discovered after a breach. The effort is not proportional to the benefit when the user base already has Google accounts.
+
+**Auth0 / Clerk / similar managed auth**
+
+Rejected for now. These services are excellent but add a vendor dependency, a paid tier at scale, and a separate admin UI. For a small internal tool, the overhead is not justified. The current implementation handles everything Auth0 would handle for this use case (SSO, session management, user identity) with less moving parts.
+
+**Server-side sessions (database-backed)**
+
+Rejected. Storing session state in a database requires a sessions table, expiry cleanup jobs, and a database query on every authenticated request. A signed JWT cookie is stateless — the server verifies the signature and expiry without any I/O. The tradeoff is that individual sessions cannot be revoked before expiry, which is acceptable for an 8-hour session window on an internal tool.
+
+**OAuth implicit flow**
+
+Rejected. The implicit flow returns tokens directly in the URL fragment, which exposes them to browser history and referrer headers. It is deprecated in OAuth 2.1. The Authorization Code flow keeps tokens out of the URL entirely.
+
+## Consequences
+
+**Security properties:**
+- Credential management (passwords, MFA, breach detection) is fully delegated to Google
+- CSRF protection via the `state` parameter round-trip
+- XSS cannot steal the session cookie (`httponly=True`)
+- Avatar URLs are validated against a `googleusercontent.com` allowlist before being stored in the JWT, preventing open redirects or content injection via a malicious picture URL
+
+**Operational notes:**
+- Requires a Google Cloud project with an OAuth 2.0 client configured. The authorized redirect URI must be set to `{BASE_URL}/auth/callback`
+- Any Google account can sign in by default — no allowlist. If the team is comfortable with this, no further config is needed. To restrict to a specific domain, add a domain check in the callback against `userinfo["hd"]` (Google's hosted domain claim)
+- Sessions cannot be forcibly revoked before the 8-hour expiry. If a session needs to be invalidated immediately (e.g. a stolen laptop), rotate `SECRET_KEY` in the environment — this invalidates all active sessions simultaneously
+- The `TEST_MODE` bypass must never be enabled in a production environment. It issues a valid session for a hardcoded fake user with no authentication check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "numpy>=1.24",
     "scipy>=1.10",
     "scikit-learn>=1.3",
+    "structlog>=24.0",
+    "langfuse>=2.0,<3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/qsf/agents/workflow.py
+++ b/src/qsf/agents/workflow.py
@@ -4,7 +4,6 @@ LangGraph pipeline for sentiment analysis.
 Graph:
     fetch_market_data → fetch_news → fetch_reddit → score_sentiment → aggregate
 """
-import logging
 from datetime import datetime
 from typing import Any, Optional
 from typing_extensions import TypedDict
@@ -12,16 +11,18 @@ from typing_extensions import TypedDict
 import pandas as pd
 from langgraph.graph import END, StateGraph
 
+from qsf.common.logging import get_current_trace, get_logger
 from qsf.common.providers import MarketDataProvider, NewsProvider, SentimentModel, SocialProvider
 from qsf.common.utils import safe, company_search_name
 from qsf.ingestion import YFinanceMarketData, NewsAPIProvider, RedditProvider
 from qsf.nlp import FinBERTModel
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class PipelineState(TypedDict, total=False):
     ticker: str
+    trace_id: str
     company_name: str
     stock_df: Any
     news_items: list
@@ -39,8 +40,11 @@ def build_pipeline(
 ):
     def _fetch_market_data(state: dict) -> dict:
         ticker = state["ticker"]
+        trace = get_current_trace()
+        span = trace.span(name="fetch_market_data", input={"ticker": ticker}) if trace else None
         hist = market.get_history(ticker, "30d")
         if hist.empty:
+            if span: span.end(output={"error": "no price data"}, level="ERROR")
             return {"error": f"No price data found for '{ticker}'"}
         stock_df = hist[["Close", "Volume"]].copy()
         stock_df.index = stock_df.index.date
@@ -55,6 +59,7 @@ def build_pipeline(
         raw_name = market.get_company_name(ticker)
         company_name = company_search_name(raw_name)
         logger.info("[%s] fetch_market_data: company name resolved to '%s'", ticker, company_name)
+        if span: span.end(output={"trading_days": days, "company_name": company_name})
         return {"stock_df": stock_df, "company_name": company_name}
 
     def _fetch_news(state: dict) -> dict:
@@ -62,19 +67,16 @@ def build_pipeline(
             return {}
         ticker = state["ticker"]
         company_name = state.get("company_name", "")
+        trace = get_current_trace()
+        span = trace.span(name="fetch_news", input={"ticker": ticker, "company_name": company_name}) if trace else None
         news_items = news.get_articles(ticker, company_name)
         count = len(news_items)
         logger.info("[%s] fetch_news: %d articles returned", ticker, count)
         if count == 0:
-            logger.warning(
-                "[%s] fetch_news: 0 articles returned — NewsAPI may be unavailable or quota exceeded",
-                ticker,
-            )
+            logger.warning("[%s] fetch_news: 0 articles returned — NewsAPI may be unavailable or quota exceeded", ticker)
         elif count < 5:
-            logger.warning(
-                "[%s] fetch_news: only %d articles returned, sentiment coverage may be sparse",
-                ticker, count,
-            )
+            logger.warning("[%s] fetch_news: only %d articles returned, sentiment coverage may be sparse", ticker, count)
+        if span: span.end(output={"count": count})
         return {"news_items": news_items}
 
     def _fetch_reddit(state: dict) -> dict:
@@ -82,16 +84,16 @@ def build_pipeline(
             return {}
         ticker = state["ticker"]
         company_name = state.get("company_name", "")
+        trace = get_current_trace()
+        span = trace.span(name="fetch_reddit", input={"ticker": ticker, "company_name": company_name}) if trace else None
         reddit_items = social.get_posts(ticker, company_name)
         count = len(reddit_items)
         logger.info("[%s] fetch_reddit: %d posts returned", ticker, count)
         for item in reddit_items:
             logger.info("[%s] fetch_reddit: post date=%s text=%s", ticker, item["date"], item["text"][:80])
         if count == 0:
-            logger.warning(
-                "[%s] fetch_reddit: 0 posts returned — Reddit API may be unavailable or ticker has low social coverage",
-                ticker,
-            )
+            logger.warning("[%s] fetch_reddit: 0 posts returned — Reddit API may be unavailable or ticker has low social coverage", ticker)
+        if span: span.end(output={"count": count})
         return {"reddit_items": reddit_items}
 
     def _score_sentiment(state: dict) -> dict:
@@ -107,6 +109,8 @@ def build_pipeline(
         )
         if not items:
             return {"error": f"No news or social data found for '{ticker}'"}
+        trace = get_current_trace()
+        span = trace.span(name="score_sentiment", input={"news": len(news_items), "social": len(reddit_items)}) if trace else None
         logger.info("[%s] score_sentiment: calling model.score on %d items", ticker, len(items))
         scores = model.score([item["text"] for item in items])
         logger.info("[%s] score_sentiment: model.score returned", ticker)
@@ -152,6 +156,7 @@ def build_pipeline(
                 "[%s] score_sentiment: mean score near zero (%.3f) — model may be returning all-neutral",
                 ticker, mean_score,
             )
+        if span: span.end(output={"scored": len(scored), "mean": round(mean_score, 4), "failed": len(items) - len(scored)})
         return {"scored_items": scored}
 
     def _aggregate(state: dict) -> dict:
@@ -161,6 +166,9 @@ def build_pipeline(
         ticker = state["ticker"]
         stock_df: pd.DataFrame = state["stock_df"]
         scored_items: list[dict] = state["scored_items"]
+
+        trace = get_current_trace()
+        span = trace.span(name="aggregate", input={"scored_items": len(scored_items)}) if trace else None
 
         df = pd.DataFrame(scored_items)
         df["date"] = pd.to_datetime(df["date"]).dt.date
@@ -254,6 +262,7 @@ def build_pipeline(
                 for idx, row in merged.iterrows()
             ],
         }
+        if span: span.end(output={"sentiment_score": safe(overall_sentiment), "trend": trend, "data_points": len(scored_items)})
         return {"result": result}
 
     graph = StateGraph(PipelineState)

--- a/src/qsf/api/auth.py
+++ b/src/qsf/api/auth.py
@@ -34,10 +34,10 @@ def _sanitize_picture(url: str) -> str:
     return ""
 
 
-def create_session_token(email: str, name: str, picture: str = "") -> str:
+def create_session_token(email: str, name: str, picture: str = "", google_sub: str = "") -> str:
     expire = datetime.now(timezone.utc) + timedelta(hours=SESSION_DURATION_HOURS)
     return jwt.encode(
-        {"sub": email, "name": name, "picture": picture, "exp": expire},
+        {"sub": email, "google_sub": google_sub, "name": name, "picture": picture, "exp": expire},
         SECRET_KEY,
         algorithm=ALGORITHM,
     )
@@ -52,7 +52,12 @@ async def get_current_user(qsent_session: str | None = Cookie(default=None)) -> 
         raise HTTPException(status_code=401, detail="Not authenticated")
     try:
         payload = decode_session_token(qsent_session)
-        return {"email": payload["sub"], "name": payload["name"], "picture": payload.get("picture", "")}
+        return {
+            "email": payload["sub"],
+            "google_sub": payload.get("google_sub", ""),
+            "name": payload["name"],
+            "picture": payload.get("picture", ""),
+        }
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
 
@@ -102,6 +107,7 @@ async def callback(request: Request):
         email=userinfo["email"],
         name=userinfo.get("name", userinfo["email"]),
         picture=_sanitize_picture(userinfo.get("picture", "")),
+        google_sub=userinfo.get("sub", ""),
     )
 
     response = RedirectResponse(url="/")
@@ -133,7 +139,7 @@ async def me(user: dict = Depends(get_current_user)):
 if os.environ.get("TEST_MODE") == "true":
     @router.get("/test-login")
     async def test_login():
-        token = create_session_token(email="test@example.com", name="Test User")
+        token = create_session_token(email="test@example.com", name="Test User", google_sub="test-user-sub")
         response = RedirectResponse(url="/")
         response.set_cookie(
             key=COOKIE_NAME,

--- a/src/qsf/api/main.py
+++ b/src/qsf/api/main.py
@@ -1,4 +1,5 @@
-import logging
+import time
+import uuid
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -6,25 +7,58 @@ from dotenv import load_dotenv
 load_dotenv()  # Must run before auth is imported so env vars are populated
 
 import httpx  # noqa: E402
-from fastapi import Depends, FastAPI, HTTPException, Query  # noqa: E402
+import structlog  # noqa: E402
+import structlog.contextvars  # noqa: E402
+from fastapi import Depends, FastAPI, HTTPException, Query, Request  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import FileResponse, Response, StreamingResponse  # noqa: E402
 from pydantic import BaseModel  # noqa: E402
+from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 
 from qsf.agents.news_comparison import run_news_comparison, run_news_comparison_stream  # noqa: E402
 from qsf.agents.workflow import pipeline  # noqa: E402
-from qsf.api.auth import get_current_user  # noqa: E402
+from qsf.api.auth import COOKIE_NAME, decode_session_token, get_current_user  # noqa: E402
 from qsf.api.auth import router as auth_router  # noqa: E402
+from qsf.common.logging import configure_logging, flush_langfuse, get_langfuse, set_current_trace, get_logger  # noqa: E402
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s  %(name)s: %(message)s",
-)
+configure_logging()
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
+log = get_logger(__name__)
+
 app = FastAPI()
 
+
+class TraceMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        trace_id = uuid.uuid4().hex
+
+        user_id = "anonymous"
+        try:
+            token = request.cookies.get(COOKIE_NAME)
+            if token:
+                payload = decode_session_token(token)
+                user_id = payload.get("google_sub") or "anonymous"
+        except Exception:
+            pass
+
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(trace_id=trace_id, user_id=user_id)
+
+        t0 = time.monotonic()
+        log.info("request.received", method=request.method, path=request.url.path)
+
+        response = await call_next(request)
+
+        duration_ms = round((time.monotonic() - t0) * 1000)
+        log.info("request.completed", status=response.status_code, duration_ms=duration_ms)
+
+        response.headers["X-Trace-ID"] = trace_id
+        return response
+
+
+app.add_middleware(TraceMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:8000"],
@@ -51,7 +85,27 @@ def health():
 
 @app.post("/analyze")
 def analyze(request: AnalyzeRequest, user: dict = Depends(get_current_user)):
-    state = pipeline.invoke({"ticker": request.ticker.upper().strip()})
+    ticker = request.ticker.upper().strip()
+    trace_id = structlog.contextvars.get_contextvars().get("trace_id", uuid.uuid4().hex)
+
+    lf = get_langfuse()
+    if lf:
+        trace = lf.trace(
+            id=trace_id,
+            name="analyze",
+            user_id=user.get("google_sub") or "anonymous",
+            session_id=ticker,
+            input={"ticker": ticker},
+        )
+        set_current_trace(trace)
+
+    state = pipeline.invoke({"ticker": ticker, "trace_id": trace_id})
+
+    if lf and not state.get("error") and state.get("result"):
+        lf.trace(id=trace_id, output={"sentiment_score": state["result"].get("sentiment_score")})
+
+    flush_langfuse()
+
     if state.get("error"):
         raise HTTPException(status_code=404, detail=state["error"])
     return state["result"]

--- a/src/qsf/common/logging.py
+++ b/src/qsf/common/logging.py
@@ -1,0 +1,109 @@
+"""
+Structured logging and tracing setup.
+
+Call configure_logging() once at startup (done in main.py).
+
+Usage in modules:
+    from qsf.common.logging import get_logger
+    logger = get_logger(__name__)
+    logger.info("fetch_news: %d articles", count)
+
+Trace context is set per-request by TraceMiddleware and flows automatically
+into every log line via structlog's contextvars.
+"""
+import contextvars
+import logging
+import os
+
+import structlog
+
+
+def get_logger(name: str):
+    return structlog.get_logger(name)
+
+
+def configure_logging() -> None:
+    json_mode = os.getenv("LOG_FORMAT", "").lower() == "json"
+    log_level = getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO)
+
+    renderer = structlog.processors.JSONRenderer() if json_mode else structlog.dev.ConsoleRenderer()
+
+    shared_pre_chain = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+
+    # Structlog native loggers (our modules): process through the shared chain,
+    # then hand off to stdlib via render_to_log_kwargs so the ProcessorFormatter
+    # below does the single final render for all log lines.
+    structlog.configure(
+        processors=shared_pre_chain + [
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.stdlib.render_to_log_kwargs,
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    # Single renderer for all logs — both our structlog lines and third-party stdlib
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+        foreign_pre_chain=shared_pre_chain,
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(log_level)
+
+
+# ---------------------------------------------------------------------------
+# Langfuse client (disabled if LANGFUSE_PUBLIC_KEY is not set)
+# ---------------------------------------------------------------------------
+
+def _init_langfuse():
+    if not os.getenv("LANGFUSE_PUBLIC_KEY"):
+        return None
+    try:
+        from langfuse import Langfuse
+        return Langfuse()
+    except Exception:
+        return None
+
+
+_langfuse = _init_langfuse()
+
+
+def get_langfuse():
+    """Return the Langfuse singleton, or None if not configured."""
+    return _langfuse
+
+
+# ContextVar holds the active Langfuse trace for the current request.
+# Set by main.py before pipeline.invoke(); read by ingestion/nlp modules.
+_CURRENT_TRACE: contextvars.ContextVar = contextvars.ContextVar("langfuse_trace", default=None)
+
+
+def set_current_trace(trace) -> None:
+    _CURRENT_TRACE.set(trace)
+
+
+def get_current_trace():
+    """Return the Langfuse trace for the current request, or None."""
+    return _CURRENT_TRACE.get()
+
+
+def flush_langfuse() -> None:
+    if _langfuse is not None:
+        _langfuse.flush()

--- a/src/qsf/ingestion/market.py
+++ b/src/qsf/ingestion/market.py
@@ -4,11 +4,21 @@ Yahoo Finance market data provider.
 import pandas as pd
 import yfinance as yf
 
+from qsf.common.logging import get_current_trace
+
 
 class YFinanceMarketData:
     def get_history(self, ticker: str, period: str) -> pd.DataFrame:
-        return yf.Ticker(ticker).history(period=period)
+        trace = get_current_trace()
+        span = trace.span(name="yfinance.get_history", input={"ticker": ticker, "period": period}) if trace else None
+        df = yf.Ticker(ticker).history(period=period)
+        if span: span.end(output={"rows": len(df)})
+        return df
 
     def get_company_name(self, ticker: str) -> str:
+        trace = get_current_trace()
+        span = trace.span(name="yfinance.get_company_name", input={"ticker": ticker}) if trace else None
         info = yf.Ticker(ticker).info
-        return info.get("longName") or info.get("shortName") or ""
+        name = info.get("longName") or info.get("shortName") or ""
+        if span: span.end(output={"name": name})
+        return name

--- a/src/qsf/ingestion/news.py
+++ b/src/qsf/ingestion/news.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta
 
 from newsapi import NewsApiClient
 
+from qsf.common.logging import get_current_trace
+
 
 def news_from_date(now: datetime, days: int = 28) -> str:
     """Return the earliest datetime string to pass to NewsAPI for `days` of history.
@@ -21,6 +23,9 @@ class NewsAPIProvider:
         client = NewsApiClient(api_key=os.getenv("NEWS_API_KEY"))
         from_date = news_from_date(datetime.now(), days)
         query = f'"{company_name}"' if company_name else ticker
+
+        trace = get_current_trace()
+        span = trace.span(name="newsapi.get_articles", input={"query": query, "days": days}) if trace else None
         response = client.get_everything(
             q=query,
             from_param=from_date,
@@ -28,7 +33,7 @@ class NewsAPIProvider:
             sort_by="publishedAt",
             page_size=100,
         )
-        return [
+        articles = [
             {
                 "text": _article_text(a),
                 "date": a["publishedAt"][:10],
@@ -37,6 +42,8 @@ class NewsAPIProvider:
             for a in response.get("articles", [])
             if a.get("title")
         ]
+        if span: span.end(output={"count": len(articles)})
+        return articles
 
 
 def _article_text(article: dict) -> str:

--- a/src/qsf/ingestion/social.py
+++ b/src/qsf/ingestion/social.py
@@ -1,13 +1,14 @@
 """
 Reddit social media provider.
 """
-import logging
 import os
 from datetime import datetime, timedelta
 
 import praw
 
-logger = logging.getLogger(__name__)
+from qsf.common.logging import get_current_trace, get_logger
+
+logger = get_logger(__name__)
 
 REDDIT_SUBREDDITS = ["stocks", "investing", "wallstreetbets", "Superstonk", "StockMarket", "QuantumComputing"]
 REDDIT_MAX_COMMENTS = 5       # top N comments by upvotes to include per post
@@ -64,8 +65,11 @@ class RedditProvider:
         )
         query = f'"{company_name}" OR "${ticker}"' if company_name else f"${ticker}"
         cutoff = datetime.now() - timedelta(days=days)
+        trace = get_current_trace()
         posts = []
         for subreddit in REDDIT_SUBREDDITS:
+            span = trace.span(name="reddit.search", input={"subreddit": subreddit, "query": query}) if trace else None
+            count = 0
             for post in reddit.subreddit(subreddit).search(
                 query, sort="new", time_filter="month", limit=50
             ):
@@ -76,4 +80,6 @@ class RedditProvider:
                         "date": created.strftime("%Y-%m-%d"),
                         "source": "social",
                     })
+                    count += 1
+            if span: span.end(output={"count": count})
         return posts

--- a/src/qsf/nlp/sentiment.py
+++ b/src/qsf/nlp/sentiment.py
@@ -1,13 +1,14 @@
 """
 HuggingFace FinBERT sentiment model.
 """
-import logging
 import os
 import time
 
 import requests
 
-logger = logging.getLogger(__name__)
+from qsf.common.logging import get_current_trace, get_logger
+
+logger = get_logger(__name__)
 
 FINBERT_URL = "https://router.huggingface.co/hf-inference/models/ProsusAI/finbert"
 SENTIMENT_MAP = {"positive": 1, "negative": -1, "neutral": 0}
@@ -27,6 +28,7 @@ class FinBERTModel:
         headers = {"Authorization": f"Bearer {os.getenv('HUGGINGFACE_API_KEY')}"}
         scores: list[float | None] = [None] * len(texts)
         failed = 0
+        trace = get_current_trace()
 
         logger.info("FinBERTModel.score: scoring %d items via HuggingFace API (1 request per item)", len(texts))
         if not texts:
@@ -63,6 +65,7 @@ class FinBERTModel:
                         "FinBERTModel.score: item %d/%d returned unexpected response: %s",
                         idx + 1, len(texts), str(result)[:200],
                     )
+                    if trace: trace.generation(name="finbert", model="ProsusAI/finbert", input=current_text[:200], level="WARNING", status_message="unexpected_response")
                     failed += 1
                     continue
                 # Single-text requests return [[{label_dicts}]] — unwrap the outer list
@@ -73,18 +76,21 @@ class FinBERTModel:
                     "FinBERTModel.score: item %d/%d — %s (%.3f)",
                     idx + 1, len(texts), top["label"].lower(), score,
                 )
+                if trace: trace.generation(name="finbert", model="ProsusAI/finbert", input=current_text[:200], output=str(round(score, 4)))
                 scores[idx] = score
             except requests.HTTPError as e:
                 logger.warning(
                     "FinBERTModel.score: item %d/%d failed — HTTP %s: %s",
                     idx + 1, len(texts), e.response.status_code, e.response.text[:200],
                 )
+                if trace: trace.generation(name="finbert", model="ProsusAI/finbert", input=text[:200], level="ERROR", status_message=f"HTTP {e.response.status_code}")
                 failed += 1
             except Exception as e:
                 logger.warning(
                     "FinBERTModel.score: item %d/%d failed — %s: %s",
                     idx + 1, len(texts), type(e).__name__, e,
                 )
+                if trace: trace.generation(name="finbert", model="ProsusAI/finbert", input=text[:200], level="ERROR", status_message=f"{type(e).__name__}: {e}")
                 failed += 1
 
         if failed:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -47,6 +47,18 @@ def test_create_session_token_picture_defaults_to_empty():
     assert payload["picture"] == ""
 
 
+def test_create_session_token_stores_google_sub():
+    token = create_session_token("user@example.com", "Test User", google_sub="116234567890")
+    payload = decode_session_token(token)
+    assert payload["google_sub"] == "116234567890"
+
+
+def test_create_session_token_google_sub_defaults_to_empty():
+    token = create_session_token("user@example.com", "Test User")
+    payload = decode_session_token(token)
+    assert payload["google_sub"] == ""
+
+
 def test_decode_expired_token_raises():
     from jose import JWTError
 
@@ -78,6 +90,20 @@ def test_me_returns_user_with_valid_cookie():
     assert data["email"] == "user@example.com"
     assert data["name"] == "Test User"
     assert data["picture"] == ""
+
+
+def test_me_returns_google_sub():
+    token = create_session_token("user@example.com", "Test User", google_sub="116234567890")
+    response = client.get("/auth/me", cookies={COOKIE_NAME: token})
+    assert response.status_code == 200
+    assert response.json()["google_sub"] == "116234567890"
+
+
+def test_me_returns_empty_google_sub_when_absent():
+    token = create_session_token("user@example.com", "Test User")
+    response = client.get("/auth/me", cookies={COOKIE_NAME: token})
+    assert response.status_code == 200
+    assert response.json()["google_sub"] == ""
 
 
 def test_me_returns_picture_when_provided():
@@ -162,6 +188,33 @@ def test_callback_sets_session_cookie(mocker):
     )
     assert response.status_code in (302, 307)
     assert COOKIE_NAME in response.cookies
+
+
+def test_callback_captures_google_sub(mocker):
+    state = "test-state-with-sub"
+
+    mock_instance = AsyncMock()
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=None)
+    mock_instance.fetch_token = AsyncMock(return_value={"access_token": "fake-token"})
+    mock_userinfo = MagicMock()
+    mock_userinfo.json.return_value = {
+        "email": "user@example.com",
+        "name": "Test User",
+        "sub": "116234567890",
+    }
+    mock_instance.get = AsyncMock(return_value=mock_userinfo)
+    mocker.patch("qsf.api.auth.AsyncOAuth2Client", return_value=mock_instance)
+
+    response = client.get(
+        f"/auth/callback?code=fake-code&state={state}",
+        cookies={"oauth_state": state},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307)
+    session_cookie = response.cookies[COOKIE_NAME]
+    payload = decode_session_token(session_cookie)
+    assert payload["google_sub"] == "116234567890"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for structured logging, trace context, and TraceMiddleware.
+"""
+import re
+
+import structlog.contextvars
+from fastapi.testclient import TestClient
+
+from qsf.api.main import app
+from qsf.common.logging import configure_logging, get_current_trace, get_langfuse, set_current_trace
+
+client = TestClient(app)
+
+TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+# ---------------------------------------------------------------------------
+# Trace context ContextVar
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_trace_returns_none_by_default():
+    set_current_trace(None)
+    assert get_current_trace() is None
+
+
+def test_set_and_get_current_trace_round_trip():
+    sentinel = object()
+    set_current_trace(sentinel)
+    assert get_current_trace() is sentinel
+    set_current_trace(None)
+
+
+# ---------------------------------------------------------------------------
+# Langfuse
+# ---------------------------------------------------------------------------
+
+
+def test_init_langfuse_returns_none_without_env_var(monkeypatch):
+    # _init_langfuse() checks LANGFUSE_PUBLIC_KEY at call time, unlike the module-level
+    # singleton which is already initialized when .env is loaded before tests run.
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    from qsf.common.logging import _init_langfuse
+    assert _init_langfuse() is None
+
+
+# ---------------------------------------------------------------------------
+# configure_logging
+# ---------------------------------------------------------------------------
+
+
+def test_configure_logging_does_not_raise():
+    configure_logging()
+
+
+def test_configure_logging_json_mode_does_not_raise(monkeypatch):
+    monkeypatch.setenv("LOG_FORMAT", "json")
+    configure_logging()
+
+
+# ---------------------------------------------------------------------------
+# TraceMiddleware — X-Trace-ID header
+# ---------------------------------------------------------------------------
+
+
+def test_trace_id_header_present_on_health():
+    response = client.get("/health")
+    assert "x-trace-id" in response.headers
+
+
+def test_trace_id_is_32_char_hex():
+    response = client.get("/health")
+    trace_id = response.headers.get("x-trace-id", "")
+    assert TRACE_ID_RE.match(trace_id), f"Expected 32-char hex, got: {trace_id!r}"
+
+
+def test_trace_id_is_unique_per_request():
+    r1 = client.get("/health")
+    r2 = client.get("/health")
+    assert r1.headers["x-trace-id"] != r2.headers["x-trace-id"]
+
+
+def test_trace_id_present_on_unauthenticated_response():
+    response = client.get("/auth/me")
+    assert response.status_code == 401
+    assert "x-trace-id" in response.headers


### PR DESCRIPTION
## Summary

- Replaces stdlib `logging.basicConfig` with structlog; every log line automatically carries `trace_id` and `user_id` via Python contextvars — no manual threading through function signatures
- `TraceMiddleware` generates a UUID trace_id per request, sets `X-Trace-ID` response header, and logs request/response with duration
- Langfuse v2 (self-hosted Docker) traces each `/analyze` call with spans per pipeline node (`fetch_market_data`, `fetch_news`, `fetch_reddit`, `score_sentiment`, `aggregate`), child spans per external API call (NewsAPI, Reddit, yfinance), and generation entries per FinBERT call
- Google OAuth `sub` (permanent opaque ID) stored in JWT and used as `user_id` in logs and traces — email never appears in logs
- `docker-compose.langfuse.yml` adds local Langfuse + Postgres for development; switch to cloud by changing three env vars

## Test plan

- [ ] `docker compose -f docker-compose.langfuse.yml up -d` — Langfuse UI at http://localhost:3000
- [ ] Set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` in `.env`
- [ ] Restart FastAPI server
- [ ] `POST /analyze` with `{"ticker": "IONQ"}` — confirm 200 response
- [ ] Check `X-Trace-ID` header in response
- [ ] Open Langfuse UI — trace appears with 5 node spans and FinBERT generations
- [ ] Confirm no email addresses in stdout logs — only `user_id=<google_sub>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)