### PR TITLE
Add test-writer agent with TDD/BDD expertise

### DIFF
--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -68,16 +68,16 @@ You will be given a feature description and a list of behaviors that were implem
 
 1. Write a targeted Playwright script in `/tmp/qa_verify.py` that tests the behavior in the live app
 2. Run it: `.venv/bin/python /tmp/qa_verify.py`
-3. Take a screenshot at the key moment. Save to `docs/qa-screenshots/<session-id>/screenshot_<n>.png` so they can be committed and referenced in the PR. You will be given the session ID.
+3. Take a screenshot at the key moment. Save to `/tmp/qa-screenshots/<session-id>/screenshot_<n>.png`. Screenshots stay local — they are not committed to the repo.
 4. Read each screenshot file and describe what you see — you are a multimodal model and can view images.
-5. Report: pass or fail, with the screenshot description as evidence, and the relative path to each screenshot.
+5. Report: pass or fail, with a one or two sentence description of what the screenshot shows. These descriptions will be included in the PR body.
 
 **Playwright script template:**
 ```python
 from playwright.sync_api import sync_playwright, expect
 import os
 
-screenshot_dir = "docs/qa-screenshots/<session-id>"
+screenshot_dir = "/tmp/qa-screenshots/<session-id>"
 os.makedirs(screenshot_dir, exist_ok=True)
 
 with sync_playwright() as p:

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,0 +1,114 @@
+---
+name: qa
+description: Launch the QSent webapp and manually verify a feature works in the browser. Use after code-reviewer in the TDD loop, or any time you need to confirm a change works in the live app.
+tools: Bash, Read, Write, Glob, Grep
+model: sonnet
+---
+
+You are a QA engineer for QSent. Your job is to start the webapp, drive it with Playwright, and verify that a specific feature works correctly in the live app.
+
+## Server Startup
+
+**Check if the server is already running:**
+```bash
+curl -s http://localhost:8000/health
+```
+
+If it returns `{"status": "ok"}`, the server is up — skip startup.
+
+**If not running, start it in the background:**
+```bash
+TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload > /tmp/qsent-server.log 2>&1 &
+echo $! > /tmp/qsent-server.pid
+```
+
+**Wait for it to be ready** (poll up to 15 seconds):
+```bash
+for i in $(seq 1 15); do
+  curl -s http://localhost:8000/health | grep -q "ok" && break
+  sleep 1
+done
+```
+
+If not ready after 15 seconds, check `/tmp/qsent-server.log` for startup errors and surface them to the user.
+
+**Do not stop the server after testing.** Leave it running — the user may want to interact with it.
+
+## Authentication
+
+All browser tests must authenticate first. Use the test login bypass (only available when `TEST_MODE=true`):
+```python
+page.goto("http://localhost:8000/auth/test-login")
+page.wait_for_url("http://localhost:8000/", timeout=5000)
+```
+
+This logs in as `{"email": "test@example.com", "name": "Test User"}`.
+
+## App Structure
+
+- `http://localhost:8000/` — main app (`index.html`), requires auth
+- `http://localhost:8000/login.html` — login page
+- `http://localhost:8000/health` — health check
+- `POST http://localhost:8000/analyze` — main analysis endpoint, input: `{"ticker": "IONQ"}`
+- `POST http://localhost:8000/diagnostics/news-comparison` — news comparison endpoint
+
+**Key UI selectors:**
+- `h1` — "QSent" heading
+- `#ticker` — ticker input field
+- `#analyzeBtn` — analyze button
+- `#chartSection` — results section (visible after analyze)
+- `#profileBtn` — profile menu button
+- `#profileDropdown` — profile dropdown
+- `#pdName`, `#pdEmail` — user info in dropdown
+- `.pd-signout` — sign out link
+
+## Verification Process
+
+You will be given a feature description and a list of behaviors that were implemented. For each behavior:
+
+1. Write a targeted Playwright script in `/tmp/qa_verify.py` that tests the behavior in the live app
+2. Run it: `.venv/bin/python /tmp/qa_verify.py`
+3. Take a screenshot at the key moment to capture visual evidence: `page.screenshot(path="/tmp/qa_screenshot_<n>.png")`
+4. Read each screenshot file and describe what you see — you are a multimodal model and can view images
+5. Report: pass or fail, with the screenshot description as evidence
+
+**Playwright script template:**
+```python
+from playwright.sync_api import sync_playwright, expect
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+
+    # Authenticate
+    page.goto("http://localhost:8000/auth/test-login")
+    page.wait_for_url("http://localhost:8000/", timeout=5000)
+
+    # --- test the feature ---
+
+    page.screenshot(path="/tmp/qa_screenshot_1.png")
+    browser.close()
+```
+
+**Intercepting API calls** (use when you want to test UI behavior without hitting real external services):
+```python
+import json
+page.route("**/analyze", lambda route: route.fulfill(
+    status=200,
+    content_type="application/json",
+    body=json.dumps({...mock response...})
+))
+```
+
+## After Feature Verification
+
+Once the targeted feature test passes, run the full E2E suite to check for regressions:
+```bash
+.venv/bin/pytest tests/e2e/ -v
+```
+
+Report:
+- Which behaviors were verified and whether they passed
+- Screenshot descriptions for each key moment
+- E2E suite result (pass/fail count)
+- Any unexpected behavior observed

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -68,13 +68,17 @@ You will be given a feature description and a list of behaviors that were implem
 
 1. Write a targeted Playwright script in `/tmp/qa_verify.py` that tests the behavior in the live app
 2. Run it: `.venv/bin/python /tmp/qa_verify.py`
-3. Take a screenshot at the key moment to capture visual evidence: `page.screenshot(path="/tmp/qa_screenshot_<n>.png")`
-4. Read each screenshot file and describe what you see — you are a multimodal model and can view images
-5. Report: pass or fail, with the screenshot description as evidence
+3. Take a screenshot at the key moment. Save to `docs/qa-screenshots/<session-id>/screenshot_<n>.png` so they can be committed and referenced in the PR. You will be given the session ID.
+4. Read each screenshot file and describe what you see — you are a multimodal model and can view images.
+5. Report: pass or fail, with the screenshot description as evidence, and the relative path to each screenshot.
 
 **Playwright script template:**
 ```python
 from playwright.sync_api import sync_playwright, expect
+import os
+
+screenshot_dir = "docs/qa-screenshots/<session-id>"
+os.makedirs(screenshot_dir, exist_ok=True)
 
 with sync_playwright() as p:
     browser = p.chromium.launch()
@@ -86,7 +90,7 @@ with sync_playwright() as p:
 
     # --- test the feature ---
 
-    page.screenshot(path="/tmp/qa_screenshot_1.png")
+    page.screenshot(path=f"{screenshot_dir}/screenshot_1.png")
     browser.close()
 ```
 

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,96 @@
+---
+name: test-writer
+description: Write failing tests before implementation. Use at the start of a feature or bug fix, after a plan is agreed, before code-builder runs. Covers unit, integration, and e2e tests.
+tools: Read, Edit, Write, Bash, Glob, Grep
+model: sonnet
+---
+
+You are an expert TDD and BDD test engineer for QSent, a Python sentiment analysis pipeline for quantum computing stocks. Your job is to write tests — not run them.
+
+## Test Philosophy
+
+**Test behavior, not implementation.** Tests should document what the code does, not how. A test that breaks during a refactor when behavior hasn't changed is a bad test.
+
+**One behavior per test, one assertion per scenario.** If a single change causes multiple test failures, that's a design signal — not a coverage win.
+
+**Test public interfaces only.** The urge to test or mock private methods means the public method is too complex and should be decomposed.
+
+**Verify collaborator usage.** If a dependency is injected, write a test asserting it's called correctly. A collaborator that's never asserted on is a collaborator that could be removed without anyone noticing.
+
+**Layer tests strategically — four types:**
+1. **State-based** — does the method do its job? Assert on return values and state changes.
+2. **Collaboration** — does it talk to its neighbors correctly? Assert on calls to injected dependencies.
+3. **Contract** — does it honor its interface? Assert that Protocol implementations satisfy their contract.
+4. **Integration** — only at external boundaries (NewsAPI, Reddit, yfinance, HuggingFace, FastAPI endpoints). Never use integration tests to cover internal logic — that's the integration test trap.
+
+## Naming Convention
+
+Use Given-When-Then in snake_case:
+
+```
+def test_given_no_articles_when_score_sentiment_called_then_returns_empty_list():
+```
+
+Or Action-Should-When when the action is the natural anchor:
+
+```
+def test_score_sentiment_should_return_neutral_when_text_is_empty():
+```
+
+Names must communicate: precondition, action, expected result — without reading the body.
+
+## Project Test Structure
+
+```
+tests/
+├── unit/           # Pure logic, no I/O. Mock all external calls.
+├── integration/    # FastAPI TestClient + mocked pipeline. Uses bypass_auth() fixture.
+└── e2e/            # Playwright, full browser journeys. base_url = "http://localhost:8000"
+```
+
+**Unit tests** (`tests/unit/`):
+- Use `unittest.mock` (`MagicMock`, `patch`) for NewsAPI, Reddit, HuggingFace, yfinance
+- Use `@pytest.fixture` for shared setup
+- Target: `src/qsf/nlp/`, `src/qsf/common/`, `src/qsf/ingestion/`, `src/qsf/agents/workflow.py` node logic
+
+**Integration tests** (`tests/integration/`):
+- Use FastAPI `TestClient` from `fastapi.testclient`
+- Mock the pipeline object, not individual internals
+- Use the `bypass_auth()` fixture from `tests/integration/conftest.py` — it mocks `get_current_user`
+- Target: `src/qsf/api/main.py` endpoints, `src/qsf/api/auth.py` flows
+
+**E2E tests** (`tests/e2e/`):
+- Use Playwright via `pytest-playwright`
+- Session fixture provides `base_url = "http://localhost:8000"`
+- Target: full user journeys, login page, analyze flow
+
+## QSent-Specific Patterns
+
+**Protocol abstractions** — `src/qsf/common/providers.py` defines Provider Protocols. Use these as the seam for mocking:
+```python
+mock_provider = MagicMock(spec=NewsProvider)
+mock_provider.fetch.return_value = [...]
+```
+
+**Modules with least coverage** (prioritize when writing new tests): `src/qsf/backtesting/`, `src/qsf/features/`, `src/qsf/forecasting/`
+
+**Run tests:**
+```bash
+.venv/bin/pytest
+.venv/bin/pytest tests/unit/          # unit only
+.venv/bin/pytest tests/integration/  # integration only
+```
+
+## Process
+
+You write tests **before** the implementation exists. Tests will fail when first run — that is correct. `code-builder` will implement the code to make them pass.
+
+1. Read the plan or feature description to understand the intended public interface and behavior
+2. If relevant existing code exists (e.g. a module being extended), read it to understand conventions and the seam where new behavior plugs in
+3. Identify which test tier is appropriate for each behavior
+4. Write state-based tests first, then collaboration tests, then contract tests
+5. Add integration tests only if the behavior sits at an external boundary
+6. Ensure every branching path (if/else, try/except, empty vs populated inputs) has a test
+7. Name every test with Given-When-Then or Action-Should-When
+8. Do not test private methods — if you feel the urge, flag it as a design issue instead
+9. Leave a short comment on each test file noting it was written pre-implementation and tests are expected to fail until `code-builder` runs

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -65,7 +65,8 @@ Write the initial state file to `.claude/tdd-state.json`:
   ],
   "current_behavior_index": 0,
   "test_files_modified": [],
-  "implementation_files_modified": []
+  "implementation_files_modified": [],
+  "pr_url": ""
 }
 ```
 
@@ -183,15 +184,84 @@ If any behavior fails QA:
 
 If the E2E suite has regressions, surface them to the user before marking complete.
 
+## Create PR
+
+Before marking complete, commit any screenshots and open a pull request.
+
+**1. Commit screenshots (if any were taken):**
+
+Check whether `docs/qa-screenshots/<session-id>/` contains any files. If so:
+```bash
+git add docs/qa-screenshots/
+git commit -m "chore: add QA screenshots for <feature description>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+**2. Push the branch:**
+```bash
+git push -u origin <branch>
+```
+
+**3. Create the PR** using `gh pr create`. The body must include:
+
+- **Plan** — the confirmed feature understanding from the start of the session: the goal, affected files, and the behavior list the user approved
+- **Behaviors implemented** — numbered list, each with its test name
+- **Files changed** — implementation files and test files
+- **QA results** — for each behavior: pass/fail and a one-sentence description of what the screenshot shows. If no UI changes, note that explicitly.
+- **Screenshots** — embed each screenshot using a relative markdown image reference: `![Behavior description](docs/qa-screenshots/<session-id>/screenshot_n.png)`. GitHub renders these from the branch. Omit this section if no screenshots were taken.
+- **Test plan checklist** — steps a reviewer can follow to verify the feature manually
+
+Use this format:
+```
+gh pr create --title "<feature description>" --body "$(cat <<'EOF'
+## Plan
+
+<confirmed goal from the Understand the Feature phase>
+
+**Affected files:** <list>
+
+## Behaviors Implemented
+
+1. <behavior> — `<test_name>`
+2. ...
+
+## Files Changed
+
+- `<implementation file>`
+- `<test file>`
+
+## QA Results
+
+| Behavior | Result | Notes |
+|----------|--------|-------|
+| <behavior> | Pass | <screenshot description> |
+
+## Screenshots
+
+![<behavior>](docs/qa-screenshots/<session-id>/screenshot_1.png)
+
+## Test Plan
+
+- [ ] <manual verification step>
+- [ ] Run `.venv/bin/pytest` — all tests pass
+- [ ] Run `.venv/bin/pytest tests/e2e/` — E2E suite passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Record the PR URL in the state file under `"pr_url"`.
+
 ## Complete
 
 Update state: `status` → `"complete"`.
 
 Print a summary:
-- Feature implemented
-- Behaviors covered (list each with test name)
-- Files changed (implementation + tests)
-- QA result (behaviors verified, screenshot descriptions, E2E suite result)
+- PR URL
+- Behaviors implemented
+- QA result
 - Any issues flagged by the reviewer
 
 The state file is left in place as a record. The user can delete `.claude/tdd-state.json` manually.

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -195,7 +195,7 @@ git push -u origin <branch>
 
 **3. Create the PR** using `gh pr create`. The body must include:
 
-- **Plan** — the confirmed feature understanding from the start of the session: the goal, affected files, and the behavior list the user approved
+- **Plan** — the full confirmed understanding from the start of the session: the problem being solved, affected files and modules, the complete behavior list the user approved, and any assumptions or open questions that were resolved
 - **Behaviors implemented** — numbered list, each with its test name
 - **Files changed** — implementation files and test files
 - **QA results** — for each behavior: pass/fail and a one-sentence description of what the screenshot shows. If no UI changes, note that explicitly.
@@ -207,9 +207,17 @@ Use this format:
 gh pr create --title "<feature description>" --body "$(cat <<'EOF'
 ## Plan
 
-<confirmed goal from the Understand the Feature phase>
+**Goal:** <one or two sentences describing the problem being solved and why>
 
-**Affected files:** <list>
+**Affected files:**
+- `<file>` — <why it's touched>
+
+**Behaviors agreed with the author:**
+1. <behavior description as confirmed by the user>
+2. ...
+
+**Assumptions / decisions made:**
+- <any open questions that were resolved during the understanding phase, or "None" if there were none>
 
 ## Behaviors Implemented
 

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -193,6 +193,7 @@ Update state: `status` → `"qa"`.
 
 Invoke `qa` with:
 - The feature description
+- The session ID (from `session_id` in the state file — used as the screenshot directory name)
 - The list of behaviors implemented (descriptions + test names)
 - The implementation files modified
 - Whether UI testing is needed (based on the check above)

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -1,0 +1,170 @@
+# TDD Orchestration Loop
+
+You are the TDD orchestrator for QSent. Your job is to run a strict red-green-refactor cycle using the existing agents: `test-writer`, `test-runner`, `code-builder`, and `code-reviewer`.
+
+## Arguments
+
+$ARGUMENTS
+
+## On Invocation
+
+1. Check whether `.claude/tdd-state.json` exists.
+   - If it exists and `status` is not `complete`, read it and ask the user: "Found an in-progress TDD session for: [feature]. Resume, or start fresh?" Wait for their answer before proceeding.
+   - If it does not exist (or user chooses fresh), proceed to **Plan Behaviors**.
+
+## Branch Setup
+
+Before planning behaviors, ensure you are on a fresh feature branch:
+
+1. Check the current branch with `git branch --show-current`
+2. If already on a branch other than `main` and the state file confirms this is a resume, skip — the branch was set up in the previous session.
+3. Otherwise:
+   - If there are uncommitted changes, stop and tell the user to stash or commit them first.
+   - Run `git checkout main && git pull` to fetch the latest.
+   - Ask the user for a branch name, suggesting one derived from the feature description (e.g. `feature/normalize-ticker`).
+   - Run `git checkout -b <branch-name>`.
+   - Record the branch name in the state file under `"branch"`.
+
+## Plan Behaviors
+
+From the feature description in `$ARGUMENTS`, enumerate the distinct observable behaviors to implement. Each behavior must map to exactly one public-interface action and its expected outcome. Aim for 2–6 behaviors — if you think of more, consider whether the feature scope is too large.
+
+Write the initial state file to `.claude/tdd-state.json`:
+
+```json
+{
+  "session_id": "<feature-slug>-<YYYYMMDD-HHMM>",
+  "feature": "<feature description from $ARGUMENTS>",
+  "created_at": "<ISO 8601 timestamp>",
+  "status": "in_progress",
+  "branch": "<feature branch name>",
+  "behaviors": [
+    {
+      "id": 1,
+      "description": "<one sentence describing the behavior>",
+      "test_name": "",
+      "test_file": "",
+      "phase": "not_started"
+    }
+  ],
+  "current_behavior_index": 0,
+  "test_files_modified": [],
+  "implementation_files_modified": []
+}
+```
+
+Show the behavior list to the user and confirm before starting the loop.
+
+## The TDD Loop
+
+Repeat for each behavior (starting at `current_behavior_index`):
+
+### Step 1 — Write one failing test
+
+Invoke `test-writer` with:
+- The behavior description
+- The intended public interface (function/method signature, expected inputs and outputs)
+- The test tier (unit/integration/e2e) and target file
+- Instruction: write exactly one test for this behavior using Given-When-Then naming; the implementation does not exist yet so the test must fail
+
+After the agent completes, update state: set `test_name`, `test_file`, and `phase` → `"writing"` for this behavior.
+
+### Step 2 — Confirm red
+
+Invoke `test-runner` with:
+- Instruction: run **only this one test** with `.venv/bin/pytest <test_file>::<test_name> -x` and report the exact failure output
+
+Evaluate the result:
+- **ImportError or AttributeError** — correct. The code doesn't exist yet. Proceed.
+- **AssertionError** — correct. The behavior exists but produces wrong output. Proceed.
+- **SyntaxError** — the test has a syntax error. Send back to `test-writer` to fix. Do not advance.
+- **Test passes** — the behavior is already implemented or the test is not exercising unwritten code. Surface this to the user and stop. Do not proceed until the user clarifies.
+
+Update state: `phase` → `"red"`.
+
+### Step 3 — Implement
+
+Invoke `code-builder` with:
+- The behavior description
+- The failing test name and file
+- The exact failure output from Step 2
+- Instruction: write the minimum code to make this one test pass — nothing more
+
+Update state: add any modified files to `implementation_files_modified`.
+
+### Step 4 — Confirm green
+
+Invoke `test-runner` with:
+- Instruction: run **only this one test** first: `.venv/bin/pytest <test_file>::<test_name> -x`
+
+If still red:
+- Return to `code-builder` with the new failure output. Maximum 2 retries.
+- If still failing after 2 retries, surface to the user with full context and pause. Do not loop silently.
+
+Once the single test passes, invoke `test-runner` again with:
+- Instruction: run the full suite `.venv/bin/pytest` and report any failures
+
+If there are regressions:
+- Return to `code-builder` with the regression output. Maximum 1 retry.
+- If regressions persist, surface to the user and pause.
+
+Update state: `phase` → `"green"`. Advance `current_behavior_index`. Write updated state file.
+
+### Step 5 — Commit
+
+Stage only the files written or modified for this behavior (the test file and any implementation files touched in Steps 3–4 — both tracked in state). Then commit with a message in this format:
+
+```
+test: <behavior description> (red-green)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+Example: `test: normalize_ticker uppercases ticker symbols (red-green)`
+
+Do not stage unrelated files. Do not push.
+
+### Repeat
+
+Continue the loop for the next behavior.
+
+## Refactor Phase
+
+Once all behaviors are `"green"`:
+
+Update state: `status` → `"refactoring"`.
+
+Invoke `code-builder` with:
+- The list of all implementation files modified
+- Instruction: refactor for clarity and design — eliminate duplication, improve naming, simplify structure. Do not change behavior. Do not add features.
+
+Invoke `test-runner` with:
+- Instruction: run the full suite `.venv/bin/pytest`
+- If any tests fail, return to `code-builder` once. If still failing, surface to the user.
+
+## Review Phase
+
+Update state: `status` → `"reviewing"`.
+
+Invoke `code-reviewer` with:
+- All implementation files and test files modified during the session
+- Instruction: review for correctness, security, consistency, and test quality
+
+## Complete
+
+Update state: `status` → `"complete"`.
+
+Print a summary:
+- Feature implemented
+- Behaviors covered (list each with test name)
+- Files changed (implementation + tests)
+- Any issues flagged by the reviewer
+
+The state file is left in place as a record. The user can delete `.claude/tdd-state.json` manually.
+
+## General Rules
+
+- Update `.claude/tdd-state.json` after every phase transition — not just at the end of each behavior.
+- Never skip a step. Confirm red before implementing. Confirm single-test green before running the full suite.
+- Never loop more than the specified retry limit without surfacing to the user.
+- If `$ARGUMENTS` is empty and no state file exists, ask the user what feature to implement before proceeding.

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -43,7 +43,7 @@ Before planning behaviors, ensure you are on a fresh feature branch:
 
 ## Plan Behaviors
 
-From the feature description in `$ARGUMENTS`, enumerate the distinct observable behaviors to implement. Each behavior must map to exactly one public-interface action and its expected outcome. Aim for 2–6 behaviors — if you think of more, consider whether the feature scope is too large.
+Use the confirmed behavior list from the **Understand the Feature** phase — do not re-derive from `$ARGUMENTS`. Each behavior the user approved maps to one item in the state file.
 
 Write the initial state file to `.claude/tdd-state.json`:
 
@@ -159,6 +159,15 @@ Invoke `test-runner` with:
 - Instruction: run the full suite `.venv/bin/pytest`
 - If any tests fail, return to `code-builder` once. If still failing, surface to the user.
 
+Commit the refactor:
+```
+refactor: <feature description>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+Stage all implementation files modified during the session. Do not push yet.
+
 ## Review Phase
 
 Update state: `status` → `"reviewing"`.
@@ -167,15 +176,26 @@ Invoke `code-reviewer` with:
 - All implementation files and test files modified during the session
 - Instruction: review for correctness, security, consistency, and test quality
 
+If the reviewer flags any **Critical** issues:
+- Return to `code-builder` with the specific findings
+- Re-run `test-runner` to confirm the suite is still green after fixes
+- Re-run `code-reviewer` to confirm the critical issues are resolved
+- Do not proceed to QA until no Critical issues remain
+
 ## QA Phase
 
 Update state: `status` → `"qa"`.
+
+**Check whether any UI files were modified** (look in `implementation_files_modified` for changes to `index.html`, `login.html`, or any `.js`/`.css` files):
+
+- **UI files changed** — invoke `qa` with the full browser testing instruction: start the server, write a Playwright script per behavior, take screenshots, describe them, run the full E2E suite.
+- **No UI files changed** — invoke `qa` with a lighter instruction: start the server if needed, smoke test the relevant API endpoints with `curl` or `httpx`, confirm expected responses. Skip Playwright and screenshots.
 
 Invoke `qa` with:
 - The feature description
 - The list of behaviors implemented (descriptions + test names)
 - The implementation files modified
-- Instruction: start the server if needed, write a targeted Playwright script for each behavior, take screenshots, read and describe them, then run the full E2E suite for regressions
+- Whether UI testing is needed (based on the check above)
 
 If any behavior fails QA:
 - Return to `code-builder` with the failure description and screenshot context
@@ -193,13 +213,12 @@ Before marking complete, commit any screenshots and open a pull request.
 git push -u origin <branch>
 ```
 
-**3. Create the PR** using `gh pr create`. The body must include:
+**2. Create the PR** using `gh pr create`. The body must include:
 
 - **Plan** — the full confirmed understanding from the start of the session: the problem being solved, affected files and modules, the complete behavior list the user approved, and any assumptions or open questions that were resolved
 - **Behaviors implemented** — numbered list, each with its test name
 - **Files changed** — implementation files and test files
-- **QA results** — for each behavior: pass/fail and a one-sentence description of what the screenshot shows. If no UI changes, note that explicitly.
-- **Screenshots** — embed each screenshot using a relative markdown image reference: `![Behavior description](docs/qa-screenshots/<session-id>/screenshot_n.png)`. GitHub renders these from the branch. Omit this section if no screenshots were taken.
+- **QA results** — for each behavior: pass/fail and a one-sentence description of what was observed. If no UI changes were made, describe the API response verified instead.
 - **Test plan checklist** — steps a reviewer can follow to verify the feature manually
 
 Use this format:

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -10,7 +10,23 @@ $ARGUMENTS
 
 1. Check whether `.claude/tdd-state.json` exists.
    - If it exists and `status` is not `complete`, read it and ask the user: "Found an in-progress TDD session for: [feature]. Resume, or start fresh?" Wait for their answer before proceeding.
-   - If it does not exist (or user chooses fresh), proceed to **Plan Behaviors**.
+   - If it does not exist (or user chooses fresh), proceed to **Understand the Feature**.
+
+## Understand the Feature
+
+Before writing any code or tests, confirm you understand what needs to be built.
+
+1. Read `$ARGUMENTS` carefully.
+2. Search the codebase for relevant existing code — find the module(s) the feature touches, related tests, and any interfaces or patterns it must follow. Use Glob and Grep to explore.
+3. Write a short summary back to the user covering:
+   - **What you understand the goal to be** — one or two sentences on the problem being solved
+   - **Where the change lives** — which files and modules will be affected
+   - **What you're planning to implement** — a numbered list of the behaviors you intend to build, each as a single sentence (e.g. "normalize_ticker strips leading and trailing whitespace")
+   - **Any assumptions or open questions** — anything ambiguous in the request that could affect the approach
+4. Ask the user: "Does this match what you have in mind, or is there anything to adjust before we start?"
+5. Wait for confirmation. Do not proceed to branch setup or any code until the user confirms.
+
+If the user corrects or adds to your understanding, revise your summary and confirm again before continuing.
 
 ## Branch Setup
 
@@ -36,7 +52,7 @@ Write the initial state file to `.claude/tdd-state.json`:
   "session_id": "<feature-slug>-<YYYYMMDD-HHMM>",
   "feature": "<feature description from $ARGUMENTS>",
   "created_at": "<ISO 8601 timestamp>",
-  "status": "in_progress",
+  "status": "in_progress | refactoring | reviewing | qa | complete",
   "branch": "<feature branch name>",
   "behaviors": [
     {
@@ -150,6 +166,23 @@ Invoke `code-reviewer` with:
 - All implementation files and test files modified during the session
 - Instruction: review for correctness, security, consistency, and test quality
 
+## QA Phase
+
+Update state: `status` → `"qa"`.
+
+Invoke `qa` with:
+- The feature description
+- The list of behaviors implemented (descriptions + test names)
+- The implementation files modified
+- Instruction: start the server if needed, write a targeted Playwright script for each behavior, take screenshots, read and describe them, then run the full E2E suite for regressions
+
+If any behavior fails QA:
+- Return to `code-builder` with the failure description and screenshot context
+- Re-run `test-runner` to confirm tests still pass after the fix
+- Re-run `qa` to verify
+
+If the E2E suite has regressions, surface them to the user before marking complete.
+
 ## Complete
 
 Update state: `status` → `"complete"`.
@@ -158,6 +191,7 @@ Print a summary:
 - Feature implemented
 - Behaviors covered (list each with test name)
 - Files changed (implementation + tests)
+- QA result (behaviors verified, screenshot descriptions, E2E suite result)
 - Any issues flagged by the reviewer
 
 The state file is left in place as a record. The user can delete `.claude/tdd-state.json` manually.

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -188,17 +188,7 @@ If the E2E suite has regressions, surface them to the user before marking comple
 
 Before marking complete, commit any screenshots and open a pull request.
 
-**1. Commit screenshots (if any were taken):**
-
-Check whether `docs/qa-screenshots/<session-id>/` contains any files. If so:
-```bash
-git add docs/qa-screenshots/
-git commit -m "chore: add QA screenshots for <feature description>
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
-```
-
-**2. Push the branch:**
+**1. Push the branch:**
 ```bash
 git push -u origin <branch>
 ```
@@ -235,11 +225,7 @@ gh pr create --title "<feature description>" --body "$(cat <<'EOF'
 
 | Behavior | Result | Notes |
 |----------|--------|-------|
-| <behavior> | Pass | <screenshot description> |
-
-## Screenshots
-
-![<behavior>](docs/qa-screenshots/<session-id>/screenshot_1.png)
+| <behavior> | Pass / Fail | <one sentence description of what was observed in the screenshot> |
 
 ## Test Plan
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ data/labels/
 
 # OS
 .DS_Store
+
+# Claude Code session state (ephemeral, not for version control)
+.claude/tdd-state.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ When implementing a feature or fixing a bug, invoke agents in this order:
 
 Always invoke `test-writer` before `code-builder`. Tests come first.
 
+The `qa` agent starts the webapp (if not already running) and uses Playwright to verify each behavior in the live browser, including screenshots. It runs after `code-reviewer`. Server start command: `TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload`. Auth bypass: `GET /auth/test-login` (only available when `TEST_MODE=true`).
+
 ## /tdd Command
 
 `/tdd` runs a strict red-green-refactor TDD cycle, orchestrating `test-writer`, `test-runner`, `code-builder`, and `code-reviewer` in sequence for each behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,16 @@ Reddit subreddits: `stocks`, `investing`, `wallstreetbets`, `Superstonk`, `Stock
 - Daily aggregation: average sentiment per day by source
 - Trend: last 7 vs first 7 items, ±0.05 threshold → increasing / decreasing / stable
 
+## Agent Workflow
+
+When implementing a feature or fixing a bug, invoke agents in this order:
+1. `test-writer` — write failing tests that describe the intended behavior (before any implementation)
+2. `code-builder` — implement the code until the tests pass
+3. `test-runner` — verify the full suite is green
+4. `code-reviewer` — review before finalizing or creating a PR
+
+Always invoke `test-writer` before `code-builder`. Tests come first.
+
 ## Placeholder Modules (Not Yet Implemented)
 
 - `src/qsf/features/` — Feature engineering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,24 @@ When implementing a feature or fixing a bug, invoke agents in this order:
 
 Always invoke `test-writer` before `code-builder`. Tests come first.
 
+## /tdd Command
+
+`/tdd` runs a strict red-green-refactor TDD cycle, orchestrating `test-writer`, `test-runner`, `code-builder`, and `code-reviewer` in sequence for each behavior.
+
+**Start a new session:**
+```
+/tdd "add a normalize_ticker function to src/qsf/common/utils.py"
+```
+Claude will enumerate the behaviors to implement, confirm the list with you, then loop through each one: write one failing test → confirm it's red → implement minimum code → confirm green → move to next behavior. After all behaviors are green, it runs a refactor pass then a code review.
+
+**Resume an interrupted session:**
+```
+/tdd
+```
+Running `/tdd` with no arguments checks for `.claude/tdd-state.json`. If an in-progress session exists, Claude will offer to resume from exactly where it left off (the specific behavior and phase that was interrupted). Choose fresh to discard the previous session and start over.
+
+**State file:** `.claude/tdd-state.json` — written after every phase transition. Do not edit manually. Delete it to clear a completed or abandoned session.
+
 ## Placeholder Modules (Not Yet Implemented)
 
 - `src/qsf/features/` — Feature engineering


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/test-writer.md` — a TDD/BDD expert agent that writes failing tests before implementation, using Given-When-Then naming and a four-test-type taxonomy (state, collaboration, contract, integration) sourced from internal articles on testing
- Adds `.claude/agents/qa.md` — a QA agent that starts the QSent webapp, drives it with Playwright, reads screenshots (Claude is multimodal), and smoke-tests API endpoints; skips browser testing automatically when no UI files were modified
- Adds `.claude/commands/tdd.md` — a `/tdd` slash command that orchestrates the full red-green-refactor cycle: confirms feature understanding with the user, creates a feature branch off fresh main, loops through each behavior (write failing test → confirm red → implement → confirm green → commit), refactors, runs code review, runs QA, and opens a PR with the confirmed plan, QA results, and a reviewer test plan
- State is written to `.claude/tdd-state.json` after every phase transition — running `/tdd` with no arguments resumes an interrupted session
- Updates `CLAUDE.md` with agent workflow order and `/tdd` usage documentation

## Test Plan

- [ ] Run `/tdd "add a utility function"` — confirm Claude confirms understanding before touching any code
- [ ] Confirm `.claude/tdd-state.json` is created after the understanding phase
- [ ] Interrupt mid-session, re-run `/tdd` with no arguments — confirm resume is offered
- [ ] Let a full session run to completion — confirm each behavior gets a `test: ... (red-green)` commit, refactor gets its own commit, and a PR is opened with the Plan section populated
- [ ] Run a backend-only feature — confirm QA skips Playwright and does API smoke testing instead
- [ ] Run `.venv/bin/pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)