### PR TITLE
Add living feature documentation generated from test suite

### DIFF
--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -159,6 +159,12 @@ Invoke `test-runner` with:
 - Instruction: run the full suite `.venv/bin/pytest`
 - If any tests fail, return to `code-builder` once. If still failing, surface to the user.
 
+Regenerate living feature docs (test names are stable after refactor):
+``` 
+python scripts/generate_features.py
+```
+If `docs/FEATURES.md` was written or changed, stage it alongside the implementation files.
+
 Commit the refactor:
 ```
 refactor: <feature description>
@@ -166,7 +172,7 @@ refactor: <feature description>
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
-Stage all implementation files modified during the session. Do not push yet.
+Stage all implementation files modified during the session plus docs/FEATURES.md if it changed. Do not push yet.
 
 ## Review Phase
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Run unit and integration tests
         run: pytest tests/unit/ tests/integration/ -v
 
+      - name: Check feature docs are up to date
+        run: python scripts/generate_features.py --check
+
   e2e:
     runs-on: ubuntu-latest
     needs: test

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,66 @@
+# QSent Features
+
+> Auto-generated from the integration and e2e test suite. Each section reflects a product feature area; each item is a verified behavior.
+
+## App Experience
+
+- Authenticated user sees app
+- Analyze renders chart
+- Logout redirects to login
+- Profile button is visible
+- Profile dropdown opens on click
+- Profile dropdown shows user info
+- Profile dropdown closes on outside click
+- Signout link navigates to logout
+
+## Login
+
+- Login page shows google button
+- Unauthenticated visit redirects to login
+- Google button points to auth login
+
+## Sentiment Analysis
+
+- Health
+- Analyze valid ticker
+- Analyze returns 404 on error
+- Analyze missing ticker
+- Analyze ticker is uppercased
+
+## Authentication
+
+- Analyze requires auth
+- News comparison requires auth
+- Health no auth required
+- Stream no auth required
+- Analyze succeeds with valid cookie
+- Avatar requires auth
+- Avatar returns 404 when no picture
+- Avatar returns 404 when picture key missing
+- Avatar returns 404 on failed fetch
+- Avatar returns 200 with image bytes
+- Avatar defaults to jpeg when no content type
+- Avatar follows redirects
+
+## News Comparison
+
+- Valid request returns 200 with correct shape
+- Tickers are uppercased
+- Whitespace tickers filtered out
+- All empty tickers returns 422
+- Missing tickers field returns 422
+- Provider error returns 200 with error in payload
+- Stream returns text event stream
+- Stream emits all expected event types
+- Stream ticker start payload
+- Stream article result has required fields
+- Stream done event is last
+- Stream empty tickers returns 422
+- Stream tickers are uppercased
+
+## Analysis Pipeline
+
+- Happy path produces result
+- Invalid ticker sets error
+- No text data sets error
+- Ticker is available throughout pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -11,6 +11,24 @@ def extract_test_names(file_path: Path) -> list[str]:
     return names
 
 
+_FEATURE_AREA_MAP = {
+    "test_analyze_endpoint": "Sentiment Analysis",
+    "test_auth_endpoints": "Authentication",
+    "test_news_comparison_endpoint": "News Comparison",
+    "test_workflow": "Analysis Pipeline",
+    "test_app_flow": "App Experience",
+    "test_login_page": "Login",
+}
+
+
+def feature_area_from_filename(filename: str) -> str:
+    stem = Path(filename).stem
+    if stem in _FEATURE_AREA_MAP:
+        return _FEATURE_AREA_MAP[stem]
+    without_prefix = stem.removeprefix("test_")
+    return without_prefix.replace("_", " ").title()
+
+
 def humanize_name(test_name: str) -> str:
     without_prefix = test_name.removeprefix("test_")
     sentence = without_prefix.replace("_", " ")

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -22,18 +22,15 @@ _FEATURE_AREA_MAP = {
 }
 
 
-def feature_area_from_filename(filename: str) -> str:
-    stem = Path(filename).stem
+def feature_area_from_filename(stem: str) -> str:
+    stem = Path(stem).stem
     if stem in _FEATURE_AREA_MAP:
         return _FEATURE_AREA_MAP[stem]
-    without_prefix = stem.removeprefix("test_")
-    return without_prefix.replace("_", " ").title()
+    return stem.removeprefix("test_").replace("_", " ").title()
 
 
 def humanize_name(test_name: str) -> str:
-    without_prefix = test_name.removeprefix("test_")
-    sentence = without_prefix.replace("_", " ")
-    return sentence.capitalize()
+    return test_name.removeprefix("test_").replace("_", " ").capitalize()
 
 
 def render_features_markdown(features: OrderedDict[str, list[str]]) -> str:
@@ -54,19 +51,20 @@ def render_features_markdown(features: OrderedDict[str, list[str]]) -> str:
 
 def collect_features(tests_dir: Path) -> OrderedDict[str, list[str]]:
     result: OrderedDict[str, list[str]] = OrderedDict()
-    subdirs = sorted(
-        [tests_dir / "integration", tests_dir / "e2e"],
-        key=lambda p: p.name,
-    )
+    candidate_dirs = [tests_dir / "e2e", tests_dir / "integration"]
     files = sorted(
-        f for subdir in subdirs for f in subdir.glob("test_*.py") if subdir.exists()
+        f
+        for subdir in candidate_dirs
+        if subdir.exists()
+        for f in subdir.glob("test_*.py")
     )
     for file_path in files:
         names = extract_test_names(file_path)
         if not names:
             continue
-        key = feature_area_from_filename(file_path.stem)
-        result[key] = [humanize_name(n) for n in names]
+        result[feature_area_from_filename(file_path.stem)] = [
+            humanize_name(n) for n in names
+        ]
     return result
 
 

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -36,6 +36,22 @@ def humanize_name(test_name: str) -> str:
     return sentence.capitalize()
 
 
+def render_features_markdown(features: OrderedDict[str, list[str]]) -> str:
+    lines = [
+        "# QSent Features",
+        "",
+        "> Auto-generated from the integration and e2e test suite. Each section reflects a product feature area; each item is a verified behavior.",
+    ]
+    for area, behaviors in features.items():
+        lines.append("")
+        lines.append(f"## {area}")
+        lines.append("")
+        for behavior in behaviors:
+            lines.append(f"- {behavior}")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def collect_features(tests_dir: Path) -> OrderedDict[str, list[str]]:
     result: OrderedDict[str, list[str]] = OrderedDict()
     subdirs = sorted(

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -1,4 +1,5 @@
 import ast
+from collections import OrderedDict
 from pathlib import Path
 
 
@@ -33,3 +34,21 @@ def humanize_name(test_name: str) -> str:
     without_prefix = test_name.removeprefix("test_")
     sentence = without_prefix.replace("_", " ")
     return sentence.capitalize()
+
+
+def collect_features(tests_dir: Path) -> OrderedDict[str, list[str]]:
+    result: OrderedDict[str, list[str]] = OrderedDict()
+    subdirs = sorted(
+        [tests_dir / "integration", tests_dir / "e2e"],
+        key=lambda p: p.name,
+    )
+    files = sorted(
+        f for subdir in subdirs for f in subdir.glob("test_*.py") if subdir.exists()
+    )
+    for file_path in files:
+        names = extract_test_names(file_path)
+        if not names:
+            continue
+        key = feature_area_from_filename(file_path.stem)
+        result[key] = [humanize_name(n) for n in names]
+    return result

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -30,7 +30,8 @@ def feature_area_from_filename(stem: str) -> str:
 
 
 def humanize_name(test_name: str) -> str:
-    return test_name.removeprefix("test_").replace("_", " ").capitalize()
+    s = test_name.removeprefix("test_").replace("_", " ")
+    return s[0].upper() + s[1:] if s else s
 
 
 def render_features_markdown(features: OrderedDict[str, list[str]]) -> str:
@@ -62,16 +63,15 @@ def collect_features(tests_dir: Path) -> OrderedDict[str, list[str]]:
         names = extract_test_names(file_path)
         if not names:
             continue
-        result[feature_area_from_filename(file_path.stem)] = [
-            humanize_name(n) for n in names
-        ]
+        area = feature_area_from_filename(file_path.stem)
+        result.setdefault(area, []).extend(humanize_name(n) for n in names)
     return result
 
 
 def check_docs(docs_path: Path, generated: str) -> bool:
     if not docs_path.exists():
         return False
-    return docs_path.read_text() == generated
+    return docs_path.read_text().replace("\r\n", "\n") == generated
 
 
 if __name__ == "__main__":

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -1,3 +1,16 @@
+import ast
+from pathlib import Path
+
+
+def extract_test_names(file_path: Path) -> list[str]:
+    tree = ast.parse(file_path.read_text())
+    names = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+            names.append(node.name)
+    return names
+
+
 def humanize_name(test_name: str) -> str:
     without_prefix = test_name.removeprefix("test_")
     sentence = without_prefix.replace("_", " ")

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -68,3 +68,30 @@ def collect_features(tests_dir: Path) -> OrderedDict[str, list[str]]:
         key = feature_area_from_filename(file_path.stem)
         result[key] = [humanize_name(n) for n in names]
     return result
+
+
+def check_docs(docs_path: Path, generated: str) -> bool:
+    if not docs_path.exists():
+        return False
+    return docs_path.read_text() == generated
+
+
+if __name__ == "__main__":
+    import sys
+
+    repo_root = Path(__file__).parent.parent
+    features = collect_features(repo_root / "tests")
+    generated = render_features_markdown(features)
+    docs_path = repo_root / "docs" / "FEATURES.md"
+
+    if "--check" in sys.argv:
+        if check_docs(docs_path, generated):
+            print("docs/FEATURES.md is up to date.")
+            sys.exit(0)
+        else:
+            print("docs/FEATURES.md is missing or out of date. Run: python scripts/generate_features.py")
+            sys.exit(1)
+    else:
+        docs_path.write_text(generated)
+        print("docs/FEATURES.md written.")
+        sys.exit(0)

--- a/scripts/generate_features.py
+++ b/scripts/generate_features.py
@@ -1,0 +1,4 @@
+def humanize_name(test_name: str) -> str:
+    without_prefix = test_name.removeprefix("test_")
+    sentence = without_prefix.replace("_", " ")
+    return sentence.capitalize()

--- a/tests/unit/test_generate_features.py
+++ b/tests/unit/test_generate_features.py
@@ -1,0 +1,15 @@
+# Written pre-implementation. Tests are expected to fail with ImportError
+# until code-builder creates scripts/generate_features.py.
+
+import sys
+import os
+
+# scripts/ is not a package and not on the default pytest path, so we insert
+# the project root so that `from scripts.generate_features import ...` resolves.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from scripts.generate_features import humanize_name  # noqa: E402
+
+
+def test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence():
+    assert humanize_name("test_analyze_valid_ticker") == "Analyze valid ticker"

--- a/tests/unit/test_generate_features.py
+++ b/tests/unit/test_generate_features.py
@@ -8,8 +8,32 @@ import os
 # the project root so that `from scripts.generate_features import ...` resolves.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from scripts.generate_features import humanize_name  # noqa: E402
+from scripts.generate_features import humanize_name, extract_test_names  # noqa: E402
 
 
 def test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence():
     assert humanize_name("test_analyze_valid_ticker") == "Analyze valid ticker"
+
+
+def test_given_file_with_mixed_functions_when_extract_test_names_called_then_returns_only_test_prefixed_names(tmp_path):
+    # Includes a top-level test function, a top-level helper, and a method inside
+    # a Test* class to verify all three cases are handled correctly.
+    test_file = tmp_path / "sample_test.py"
+    test_file.write_text(
+        "def test_alpha():\n"
+        "    pass\n"
+        "\n"
+        "def helper_setup():\n"
+        "    pass\n"
+        "\n"
+        "class TestBeta:\n"
+        "    def test_beta_method(self):\n"
+        "        pass\n"
+        "\n"
+        "    def not_a_test(self):\n"
+        "        pass\n"
+    )
+
+    names = extract_test_names(test_file)
+
+    assert sorted(names) == ["test_alpha", "test_beta_method"]

--- a/tests/unit/test_generate_features.py
+++ b/tests/unit/test_generate_features.py
@@ -10,7 +10,7 @@ import pytest
 # the project root so that `from scripts.generate_features import ...` resolves.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename  # noqa: E402
+from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename, collect_features  # noqa: E402
 
 
 def test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence():
@@ -52,3 +52,28 @@ def test_given_file_with_mixed_functions_when_extract_test_names_called_then_ret
 ])
 def test_given_filename_stem_when_feature_area_from_filename_called_then_returns_readable_area_name(stem, expected):
     assert feature_area_from_filename(stem) == expected
+
+
+def test_given_integration_and_e2e_test_files_when_collect_features_called_then_returns_ordered_dict_with_humanized_behaviors(tmp_path):
+    # Pre-implementation — expected to fail until code-builder adds collect_features to
+    # scripts/generate_features.py.
+    (tmp_path / "integration").mkdir()
+    (tmp_path / "e2e").mkdir()
+
+    (tmp_path / "integration" / "test_foo_endpoint.py").write_text(
+        "def test_bar():\n"
+        "    pass\n"
+        "\n"
+        "def test_baz():\n"
+        "    pass\n"
+    )
+    (tmp_path / "e2e" / "test_login_page.py").write_text(
+        "def test_google_button():\n"
+        "    pass\n"
+    )
+
+    result = collect_features(tmp_path)
+
+    assert len(result) == 2
+    assert "Login" in result
+    assert "Google button" in result["Login"]

--- a/tests/unit/test_generate_features.py
+++ b/tests/unit/test_generate_features.py
@@ -10,7 +10,9 @@ import pytest
 # the project root so that `from scripts.generate_features import ...` resolves.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename, collect_features  # noqa: E402
+from collections import OrderedDict
+
+from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename, collect_features, render_features_markdown  # noqa: E402
 
 
 def test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence():
@@ -77,3 +79,22 @@ def test_given_integration_and_e2e_test_files_when_collect_features_called_then_
     assert len(result) == 2
     assert "Login" in result
     assert "Google button" in result["Login"]
+
+
+def test_given_ordered_dict_with_two_feature_areas_when_render_features_markdown_called_then_produces_valid_markdown():
+    features = OrderedDict([
+        ("Authentication", ["Log in with Google", "Reject expired token"]),
+        ("Analysis Pipeline", ["Fetch market data", "Score sentiment"]),
+    ])
+
+    output = render_features_markdown(features)
+
+    assert output.startswith("# QSent Features")
+    assert "## Authentication\n" in output
+    assert "## Analysis Pipeline\n" in output
+    assert "- Log in with Google\n" in output
+    assert "- Reject expired token\n" in output
+    assert "- Fetch market data\n" in output
+    assert "- Score sentiment\n" in output
+    # Determinism: calling twice with the same input must return identical output
+    assert render_features_markdown(features) == output

--- a/tests/unit/test_generate_features.py
+++ b/tests/unit/test_generate_features.py
@@ -4,11 +4,13 @@
 import sys
 import os
 
+import pytest
+
 # scripts/ is not a package and not on the default pytest path, so we insert
 # the project root so that `from scripts.generate_features import ...` resolves.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from scripts.generate_features import humanize_name, extract_test_names  # noqa: E402
+from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename  # noqa: E402
 
 
 def test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence():
@@ -37,3 +39,16 @@ def test_given_file_with_mixed_functions_when_extract_test_names_called_then_ret
     names = extract_test_names(test_file)
 
     assert sorted(names) == ["test_alpha", "test_beta_method"]
+
+
+@pytest.mark.parametrize("stem, expected", [
+    ("test_analyze_endpoint", "Sentiment Analysis"),
+    ("test_auth_endpoints", "Authentication"),
+    ("test_news_comparison_endpoint", "News Comparison"),
+    ("test_workflow", "Analysis Pipeline"),
+    ("test_app_flow", "App Experience"),
+    ("test_login_page", "Login"),
+    ("test_some_new_thing", "Some New Thing"),
+])
+def test_given_filename_stem_when_feature_area_from_filename_called_then_returns_readable_area_name(stem, expected):
+    assert feature_area_from_filename(stem) == expected

--- a/tests/unit/test_generate_features.py
+++ b/tests/unit/test_generate_features.py
@@ -1,18 +1,15 @@
-# Written pre-implementation. Tests are expected to fail with ImportError
-# until code-builder creates scripts/generate_features.py.
-
-import sys
-import os
+from collections import OrderedDict
 
 import pytest
 
-# scripts/ is not a package and not on the default pytest path, so we insert
-# the project root so that `from scripts.generate_features import ...` resolves.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-
-from collections import OrderedDict
-
-from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename, collect_features, render_features_markdown, check_docs  # noqa: E402
+from scripts.generate_features import (
+    check_docs,
+    collect_features,
+    extract_test_names,
+    feature_area_from_filename,
+    humanize_name,
+    render_features_markdown,
+)
 
 
 def test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence():

--- a/tests/unit/test_generate_features.py
+++ b/tests/unit/test_generate_features.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from collections import OrderedDict
 
-from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename, collect_features, render_features_markdown  # noqa: E402
+from scripts.generate_features import humanize_name, extract_test_names, feature_area_from_filename, collect_features, render_features_markdown, check_docs  # noqa: E402
 
 
 def test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence():
@@ -98,3 +98,21 @@ def test_given_ordered_dict_with_two_feature_areas_when_render_features_markdown
     assert "- Score sentiment\n" in output
     # Determinism: calling twice with the same input must return identical output
     assert render_features_markdown(features) == output
+
+
+def test_check_docs_should_return_correct_result_for_missing_matching_and_differing_content(tmp_path):
+    # Pre-implementation — expected to fail with ImportError until code-builder
+    # adds check_docs to scripts/generate_features.py.
+    docs_file = tmp_path / "FEATURES.md"
+    generated = "# QSent Features\n\n## Auth\n\n- Log in\n"
+
+    # Case 1: file does not exist
+    assert check_docs(docs_file, generated) is False
+
+    # Case 2: file exists and contents match exactly
+    docs_file.write_text(generated)
+    assert check_docs(docs_file, generated) is True
+
+    # Case 3: file exists but contents differ
+    docs_file.write_text(generated + "\nextra line\n")
+    assert check_docs(docs_file, generated) is False


### PR DESCRIPTION
## Plan

**Goal:** QSent had no single place where someone could read what the product actually does. This PR adds a `docs/FEATURES.md` that enumerates every product behavior — organized by feature area, in plain English — and stays automatically current as features are added or changed. The source of truth is the test suite: integration and e2e test names are parsed via `ast`, humanized, and rendered into the doc on every feature completion.

**Affected files:**
- `scripts/generate_features.py` — new doc generator script
- `tests/unit/test_generate_features.py` — unit tests for the generator
- `docs/FEATURES.md` — the generated output (committed, checked in CI)
- `.github/workflows/ci.yml` — added `--check` step to fail PRs with stale docs
- `pyproject.toml` — added `pythonpath = ["."]` so test imports work without sys.path hacks

**Behaviors agreed with the author:**
1. `humanize_name` strips `test_` prefix and converts snake_case to a readable capitalized sentence
2. `extract_test_names` uses `ast.parse` to return all test_ function names from a Python file without importing it
3. `feature_area_from_filename` maps test file stems to human-readable feature area names
4. `collect_features` walks integration and e2e subdirectories and returns an OrderedDict of feature area to behavior list
5. `render_features_markdown` produces a Markdown string with a header block and one section per feature area
6. `check_docs` + CLI `--check` exits 0 when docs are current, 1 when stale; CI step added

**Assumptions / decisions made:**
- Unit tests are excluded (they describe implementation details, not product behaviors) — only integration + e2e tests feed the doc
- Docs are regenerated once per feature at the end of the TDD refactor phase, not after each individual behavior, so test names are stable before they're baked into the doc
- `ast.walk` mirrors pytest's own collection behavior for finding test functions; accidental `test_`-prefixed helpers in non-test classes are an accepted edge case (same as pytest itself)

## Behaviors Implemented

1. humanize_name strips test_ prefix and converts to readable sentence — `test_given_snake_case_test_name_when_humanize_name_called_then_returns_capitalized_sentence`
2. extract_test_names returns only test-prefixed names via ast.parse — `test_given_file_with_mixed_functions_when_extract_test_names_called_then_returns_only_test_prefixed_names`
3. feature_area_from_filename maps stems to feature area names — `test_given_test_file_stems_when_feature_area_from_filename_called_then_returns_correct_area_names`
4. collect_features returns OrderedDict of feature areas and behaviors — `test_given_integration_and_e2e_test_files_when_collect_features_called_then_returns_ordered_dict_with_humanized_behaviors`
5. render_features_markdown produces structured Markdown — `test_given_ordered_dict_with_two_feature_areas_when_render_features_markdown_called_then_produces_valid_markdown`
6. check_docs returns True/False based on file match — `test_check_docs_should_return_correct_result_for_missing_matching_and_differing_content`

## Files Changed

- `scripts/generate_features.py`
- `tests/unit/test_generate_features.py`
- `docs/FEATURES.md`
- `.github/workflows/ci.yml`
- `pyproject.toml`

## QA Results

| Behavior | Result | Notes |
|----------|--------|-------|
| Script writes FEATURES.md with readable sections | Pass | Produced 6 sections and 45 behavior items |
| --check exits 0 when file is current | Pass | Prints "up to date" and exits 0 immediately after generation |
| --check exits 1 when file is stale | Pass | Modified file caused exit 1; restoring brought it back to exit 0 |
| At least 4 sections and 10 behaviors | Pass | 6 sections, 45 behaviors |
| CI --check step present after test step | Pass | Step added at line 26 in ci.yml, directly after pytest |

## Test Plan

- [ ] Run `python scripts/generate_features.py` — `docs/FEATURES.md` appears with all 6 feature sections
- [ ] Run `python scripts/generate_features.py --check` — exits 0
- [ ] Add a new test function to any file in `tests/integration/`, run `--check` without regenerating — exits 1
- [ ] Run `.venv/bin/pytest tests/unit/test_generate_features.py` — all 12 tests pass
- [ ] Run `.venv/bin/pytest tests/unit/ tests/integration/` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)