### PR TITLE
Enrich CLAUDE.md as shared codebase cache; keep it fresh via /tdd

### DIFF
--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -165,6 +165,19 @@ python scripts/generate_features.py
 ```
 If `docs/FEATURES.md` was written or changed, stage it alongside the implementation files.
 
+Update `CLAUDE.md` if the implementation changed anything it documents. Check `implementation_files_modified` against the current `CLAUDE.md` content and update only the sections that are now stale or incomplete. Sections to check:
+
+- **Key source files** — if a new module or file was added to `src/qsf/`, add it with a one-line description
+- **API Endpoints** — if a new endpoint was added or an existing one changed its contract, update the list
+- **Provider Pattern** — if a new provider protocol or concrete implementation was added, reflect it
+- **Pipeline flow** — if the LangGraph graph structure changed (new node, reordered edges), update the flow description
+- **Placeholder Modules** — if a placeholder was implemented (moved from placeholder to real), remove it from that section
+- **Data Sources table** — if a new external data source was introduced, add a row
+
+Do not rewrite sections unaffected by this session. Do not change the Agent Workflow, /tdd Command, or Architecture Decision Records sections. If nothing in `CLAUDE.md` is stale after this session, skip this step entirely.
+
+If `CLAUDE.md` was changed, stage it alongside the implementation files.
+
 Commit the refactor:
 ```
 refactor: <feature description>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,143 @@
-# QSent — Project Context for Claude
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## What This Project Is
 
-QSent is a sentiment analysis pipeline for **quantum computing stocks**. The goal is to generate daily stock price movement predictions by combining market data, news sentiment, and social media sentiment into a unified signal.
+QSent is a sentiment analysis pipeline for **quantum computing stocks**. It combines market data (Yahoo Finance), news sentiment (NewsAPI), and social sentiment (Reddit) into a unified daily score, exposed via a FastAPI REST API and a browser frontend.
 
-The longer-term vision is a full AI forecasting system — using sentiment as a feature for predicting price movement, with backtesting capabilities.
+The longer-term vision is a full AI forecasting system with backtesting. A `ForecastingPipeline` is partially implemented in `src/qsf/forecasting/` but not yet wired into the API.
 
-## Current State
+## Commands
 
-Early stage. The core ingestion and scoring pipeline is functional, exposed via a FastAPI REST API. Development is focused on validating data quality and tuning the sentiment pipeline.
+```bash
+# Install (first time)
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+
+# Run server (normal — requires Google OAuth credentials in .env)
+.venv/bin/uvicorn qsf.api.main:app --reload
+
+# Run server (test mode — bypasses Google auth)
+TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload
+
+# Run all fast tests
+.venv/bin/pytest tests/unit/ tests/integration/
+
+# Run a single test file
+.venv/bin/pytest tests/unit/test_nodes.py
+
+# Run a single test by name
+.venv/bin/pytest tests/unit/test_nodes.py::TestFetchMarketData::test_returns_error_on_empty_history
+
+# Run E2E tests (requires server running in TEST_MODE)
+.venv/bin/playwright install chromium  # first time only
+.venv/bin/pytest tests/e2e/
+
+# Optional: start Langfuse tracing UI (Docker required)
+docker compose -f docker-compose.langfuse.yml up -d
+```
+
+No lint or formatter is configured yet. There is no `Makefile` with useful targets.
 
 ## Architecture
 
 **Pipeline flow (LangGraph, sequential):**
-1. `fetch_market_data` — 30-day OHLCV + company name via Yahoo Finance
-2. `fetch_news` — Articles from NewsAPI (company name or ticker query)
-3. `fetch_reddit` — Posts/comments from 6 investing subreddits via PRAW
-4. `score_sentiment` — FinBERT (ProsusAI/finbert via HuggingFace Inference API)
-5. `aggregate` — Daily sentiment time series aligned to trading days
+`fetch_market_data` → `fetch_news` → `fetch_reddit` → `score_sentiment` → `aggregate`
+
+Each node returns a partial `PipelineState` dict. If any node sets `state["error"]`, all downstream nodes skip execution by checking `state.get("error")` at entry.
 
 **Key source files:**
-- `src/qsf/api/main.py` — FastAPI app
-- `src/qsf/agents/workflow.py` — LangGraph pipeline
-- `src/qsf/ingestion/market.py` — Yahoo Finance provider
-- `src/qsf/ingestion/news.py` — NewsAPI provider
-- `src/qsf/ingestion/social.py` — Reddit provider
-- `src/qsf/nlp/sentiment.py` — FinBERT sentiment model
-- `src/qsf/common/utils.py` — Company name normalization, helpers
+- `src/qsf/api/main.py` — FastAPI app, `TraceMiddleware`, endpoint handlers
+- `src/qsf/api/auth.py` — Google OAuth 2.0 flow, JWT session cookies, `get_current_user` dependency
+- `src/qsf/agents/workflow.py` — `build_pipeline()` factory + module-level `pipeline` instance
+- `src/qsf/agents/news_comparison.py` — separate LangGraph pipeline for the diagnostics endpoint
+- `src/qsf/common/providers.py` — `typing.Protocol` interfaces for all four external dependencies
+- `src/qsf/common/logging.py` — structlog setup, Langfuse singleton, per-request trace context
+- `src/qsf/common/utils.py` — `safe()` (numpy → JSON float), `company_search_name()` (strips legal suffixes)
+- `src/qsf/ingestion/market.py` — `YFinanceMarketData`
+- `src/qsf/ingestion/news.py` — `NewsAPIProvider`
+- `src/qsf/ingestion/social.py` — `RedditProvider`
+- `src/qsf/nlp/sentiment.py` — `FinBERTModel` (HuggingFace Inference API)
 
-**Frontend:** `index.html` — browser prototype using Chart.js, calls `/analyze`
+**Frontend:** `index.html` and `login.html` are served directly by FastAPI. Chart.js from CDN — no build step.
+
+## Provider Pattern (Critical for Testing)
+
+The four external dependencies are abstracted as `typing.Protocol` classes in `src/qsf/common/providers.py`:
+
+```python
+MarketDataProvider  →  get_history(ticker, period) -> DataFrame
+                        get_company_name(ticker) -> str
+NewsProvider        →  get_articles(ticker, company_name, days) -> list[dict]
+SocialProvider      →  get_posts(ticker, company_name, days) -> list[dict]
+SentimentModel      →  score(texts) -> list[float | None]
+```
+
+Providers are injected via `build_pipeline(market, news, social, model)`. The module-level `pipeline` in `workflow.py` wires up the production providers.
+
+**Tests use direct injection, not `@patch`:**
+```python
+market, news, social, model = make_providers()  # MagicMocks
+pipeline = build_pipeline(market, news, social, model)
+state = pipeline.invoke({"ticker": "IONQ"})
+```
+
+Never use `@patch("qsf.agents.workflow....")` for node tests — inject via `build_pipeline()` instead. See `tests/unit/test_nodes.py` for the canonical pattern including the `make_providers()` helper.
+
+Provider item dict shapes:
+- News/Social items: `{"text": str, "date": "YYYY-MM-DD", "source": "news"|"social"}`
+- `SentimentModel.score()` always returns a list the same length as input. `None` at an index = that item failed.
 
 ## API Endpoints
 
-- `GET /health` — Health check
-- `POST /analyze` — Main endpoint. Input: `{"ticker": "IONQ"}`. Returns sentiment score, news/social breakdown, trend, and daily data series.
-- Diagnostics endpoint — Used during development to inspect raw data fetching and scoring behavior for troubleshooting.
+- `GET /health` — unauthenticated health check
+- `POST /analyze` — main endpoint; input `{"ticker": "IONQ"}`; returns sentiment score, breakdown, trend, daily data series
+- `POST /diagnostics/news-comparison` — compare news across multiple tickers
+- `GET /diagnostics/news-comparison/stream` — SSE streaming version of the above
 
-## Data Sources
+All endpoints except `/health` require a valid session cookie (`qsent_session`).
 
-| Source | Library | Window |
-|--------|---------|--------|
-| Market data | yfinance | 30 days |
-| News | newsapi-python | 28 days (free plan limit) |
-| Social | praw (Reddit) | 30 days |
-| Sentiment model | HuggingFace FinBERT | per-text scoring |
+## Authentication
 
-Reddit subreddits: `stocks`, `investing`, `wallstreetbets`, `Superstonk`, `StockMarket`, `QuantumComputing`
+Google OAuth 2.0 Authorization Code flow. Sessions stored as signed HttpOnly JWT cookies, 8-hour expiry.
+
+**Key auth files:** `src/qsf/api/auth.py` — handles `/auth/login`, `/auth/callback`, `/auth/logout`, `/auth/me`.
+
+**Integration test auth bypass:**
+```python
+# tests/integration/conftest.py — applied autouse to all integration tests
+app.dependency_overrides[get_current_user] = lambda: MOCK_USER
+```
+
+**QA/E2E bypass (TEST_MODE only):**
+```bash
+TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload
+# Then visit http://localhost:8000/auth/test-login once to get a session cookie
+```
+
+The `TEST_MODE` route is never registered unless `TEST_MODE=true`. Never enable it in production.
+
+**PII rule:** `user_id` in logs and Langfuse traces is always the Google `sub` (an opaque permanent ID like `"116234567890"`), never the user's email. The JWT stores both `sub` (email) and `google_sub` (Google's opaque ID) for legacy reasons, but observability code uses `google_sub` exclusively.
+
+## Observability
+
+Two correlated systems per request:
+
+**structlog** — structured logs with `trace_id` and `user_id` bound per-request by `TraceMiddleware`. Every log line across the entire stack (including third-party libraries) carries these fields. Set `LOG_FORMAT=json` for machine-readable output in production.
+
+**Langfuse v2** — agentic trace UI. One trace per `/analyze` request, five child spans (one per pipeline node). Optional: if `LANGFUSE_PUBLIC_KEY` is not set, tracing silently disables and the pipeline runs normally. Pinned to `langfuse>=2.0,<3.0` — v3 requires ClickHouse, which is not set up.
+
+The same `trace_id` links stdout logs to the Langfuse UI. The `X-Trace-ID` response header carries it for client-side correlation.
 
 ## Sentiment Scoring
 
 - FinBERT classifies each text as positive (+1), neutral (0), or negative (-1), weighted by confidence
 - News: title + description combined
 - Reddit: title + body + top 5 comments by upvotes, capped at 1800 chars
-- Daily aggregation: average sentiment per day by source
-- Trend: last 7 vs first 7 items, ±0.05 threshold → increasing / decreasing / stable
+- Daily aggregation: average sentiment per day per source, forward-filled across calendar days to the next trading day
+- Overall score: average of `news_mean` and `social_mean`
+- Trend: last 7 vs first 7 scored items, ±0.05 threshold → `increasing` / `decreasing` / `stable`
 
 ## Agent Workflow
 
@@ -85,9 +169,31 @@ Running `/tdd` with no arguments checks for `.claude/tdd-state.json`. If an in-p
 
 **State file:** `.claude/tdd-state.json` — written after every phase transition. Do not edit manually. Delete it to clear a completed or abandoned session.
 
+## Data Sources
+
+| Source | Library | Window |
+|--------|---------|--------|
+| Market data | yfinance | 30 days |
+| News | newsapi-python | 28 days (free plan limit) |
+| Social | praw (Reddit) | 30 days |
+| Sentiment model | HuggingFace FinBERT | per-text scoring |
+
+Reddit subreddits: `stocks`, `investing`, `wallstreetbets`, `Superstonk`, `StockMarket`, `QuantumComputing`
+
 ## Placeholder Modules (Not Yet Implemented)
 
 - `src/qsf/features/` — Feature engineering
-- `src/qsf/forecasting/` — Price movement prediction
+- `src/qsf/forecasting/` — Price movement prediction (partially implemented, not wired into API)
 - `src/qsf/backtesting/` — Historical validation
 - `src/qsf/pipelines/` — End-to-end pipeline orchestration
+
+## Architecture Decision Records
+
+Key decisions are documented in `docs/decisions/`:
+- `001` — Protocol-based provider abstractions (why `typing.Protocol` over ABC or DI framework)
+- `002` — NewsAPI 28-day date window
+- `003` — FinBERT scoring reliability
+- `004` — Reddit text enrichment (comments + char cap)
+- `005` — Company name search query (why `company_search_name()` strips legal suffixes)
+- `006` — Observability: structlog + Langfuse v2 (why not LangSmith, Phoenix, or v3)
+- `007` — Google SSO (why not Auth0, username/password, or implicit flow)


### PR DESCRIPTION
## Summary

- Rewrites `CLAUDE.md` to serve as a pre-loaded index for Claude Code sessions, reducing the codebase exploration phase at the start of each `/tdd` run (~2 min saved per session)
- Adds dev commands, the provider injection pattern, auth/observability details, test patterns, and ADR pointers — the context that was previously being re-derived from scratch each time
- Adds a targeted `CLAUDE.md` update step to the `/tdd` Refactor Phase so the index stays current when new modules, endpoints, or providers are added

## What changed in CLAUDE.md

**Added:**
- All development commands (install, run server, run tests, single test, E2E, Langfuse)
- `TEST_MODE` server start and auth bypass pattern
- Provider Pattern section — explains `build_pipeline()` injection and why `@patch` is wrong for node tests (the most critical pattern for `/tdd` to understand test structure without exploring)
- Integration test auth bypass pattern (`dependency_overrides`)
- Observability details — structlog + Langfuse, the optional `LANGFUSE_PUBLIC_KEY` gate, Langfuse v2 pin rationale
- PII rule — `google_sub` not email in logs/traces
- Pointer to all 7 ADRs

**Kept:** pipeline flow, key files, API endpoints, data sources, sentiment scoring, agent workflow, `/tdd` docs, placeholder modules.

## What changed in `.claude/commands/tdd.md`

Added a CLAUDE.md update step to the Refactor Phase (between `generate_features.py` and the refactor commit). It checks `implementation_files_modified` and updates only stale sections — key files, endpoints, providers, pipeline flow, placeholder modules, data sources. Explicitly skips agent workflow, `/tdd` docs, and ADR sections. No-op if nothing is stale.

## Test plan

- [ ] Start a `/tdd` session and confirm the Understand the Feature phase no longer spends time exploring files already documented in `CLAUDE.md`
- [ ] After a `/tdd` session that adds a new module or endpoint, confirm the Refactor Phase updates the relevant `CLAUDE.md` section and stages it in the refactor commit
- [ ] Confirm a `/tdd` session that only modifies existing modules does not touch `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)