### PR TITLE
Add autonomous GitHub Actions agent for issue-to-PR workflow

### DIFF
--- a/.github/prompts/implement.md
+++ b/.github/prompts/implement.md
@@ -1,0 +1,16 @@
+Implement the feature described in this GitHub issue.
+
+Follow the TDD workflow strictly:
+1. Write failing tests first that describe the intended behavior
+2. Implement the minimum code to make the tests pass
+3. Verify the full test suite is green
+4. Open a PR linked to this issue
+
+Branch naming: create a branch named auto/issue-$ISSUE_NUMBER.
+
+PR body must include "Closes #$ISSUE_NUMBER" so the issue closes
+automatically on merge and the PR can be detected by other workflows.
+
+Project context is in CLAUDE.md. Tests live in tests/unit/ and
+tests/integration/. Run tests with:
+  .venv/bin/pytest tests/unit/ tests/integration/

--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -1,0 +1,9 @@
+Review the open PR linked to issue #$ISSUE_NUMBER.
+
+Check that:
+1. The implementation matches the issue requirements
+2. Tests exist and cover the new behaviour
+3. The full test suite passes
+
+Post a comment on the PR summarising your findings. Flag any gaps
+between the issue requirements and what was implemented.

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -1,4 +1,4 @@
-name: Autonomous Feature Agent
+name: Autonomous Implementation
 
 on:
   issues:
@@ -29,14 +29,23 @@ jobs:
               state: 'open'
             });
             const issueNumber = context.payload.issue.number;
-            const linked = prs.data.some(pr =>
+            const linked = prs.data.find(pr =>
               pr.body && pr.body.includes(`#${issueNumber}`)
             );
-            return linked;
-          result-encoding: string
+            if (linked) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `⚠️ Implementation aborted — [PR #${linked.number}](${linked.html_url}) already exists for this issue. Apply the \`autonomous-review\` label to validate it instead.`
+              });
+              core.setOutput('pr_exists', 'true');
+            } else {
+              core.setOutput('pr_exists', 'false');
+            }
 
       - name: Implement
-        if: steps.check-pr.outputs.result == 'false'
+        if: steps.check-pr.outputs.pr_exists == 'false'
         uses: anomalyco/opencode/github@latest
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
@@ -54,16 +63,3 @@ jobs:
             Project context is in CLAUDE.md. Tests live in tests/unit/ and
             tests/integration/. Run tests with:
               .venv/bin/pytest tests/unit/ tests/integration/
-
-      - name: Validate existing PR
-        if: steps.check-pr.outputs.result == 'true'
-        uses: anomalyco/opencode/github@latest
-        env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-        with:
-          model: google/gemini-2.0-flash
-          prompt: |
-            A PR already exists for this issue. Review the open PR linked
-            to issue #${{ github.event.issue.number }}. Check that the
-            implementation matches the issue requirements and the tests
-            pass. Post a comment on the PR summarising your findings.

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
-          model: google/gemini-2.0-flash
+          model: google/gemini-2.5-flash
           prompt: |
             Implement the feature described in this GitHub issue.
 

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -60,6 +60,12 @@ jobs:
             3. Verify the full test suite is green
             4. Open a PR linked to this issue
 
+            Branch naming: create a branch named auto/issue-${{ github.event.issue.number }}.
+
+            PR body must include "Closes #${{ github.event.issue.number }}" so the
+            issue closes automatically on merge and the PR can be detected by other
+            workflows.
+
             Project context is in CLAUDE.md. Tests live in tests/unit/ and
             tests/integration/. Run tests with:
               .venv/bin/pytest tests/unit/ tests/integration/

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -44,6 +44,16 @@ jobs:
               core.setOutput('pr_exists', 'false');
             }
 
+      - name: Read prompt
+        id: read-prompt
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        run: |
+          content=$(cat .github/prompts/implement.md)
+          content="${content//\$ISSUE_NUMBER/${{ github.event.issue.number }}}"
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$content" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Implement
         if: steps.check-pr.outputs.pr_exists == 'false'
         uses: anomalyco/opencode/github@latest
@@ -51,21 +61,4 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
           model: google/gemini-2.5-flash
-          prompt: |
-            Implement the feature described in this GitHub issue.
-
-            Follow the TDD workflow strictly:
-            1. Write failing tests first that describe the intended behavior
-            2. Implement the minimum code to make the tests pass
-            3. Verify the full test suite is green
-            4. Open a PR linked to this issue
-
-            Branch naming: create a branch named auto/issue-${{ github.event.issue.number }}.
-
-            PR body must include "Closes #${{ github.event.issue.number }}" so the
-            issue closes automatically on merge and the PR can be detected by other
-            workflows.
-
-            Project context is in CLAUDE.md. Tests live in tests/unit/ and
-            tests/integration/. Run tests with:
-              .venv/bin/pytest tests/unit/ tests/integration/
+          prompt: ${{ steps.read-prompt.outputs.content }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
-          model: google/gemini-2.0-flash
+          model: google/gemini-2.5-flash
           prompt: |
             Review the open PR linked to issue #${{ github.event.issue.number }}.
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -18,18 +18,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Read prompt
+        id: read-prompt
+        run: |
+          content=$(cat .github/prompts/review.md)
+          content="${content//\$ISSUE_NUMBER/${{ github.event.issue.number }}}"
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$content" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - uses: anomalyco/opencode/github@latest
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
           model: google/gemini-2.5-flash
-          prompt: |
-            Review the open PR linked to issue #${{ github.event.issue.number }}.
-
-            Check that:
-            1. The implementation matches the issue requirements
-            2. Tests exist and cover the new behaviour
-            3. The full test suite passes
-
-            Post a comment on the PR summarising your findings. Flag any
-            gaps between the issue requirements and what was implemented.
+          prompt: ${{ steps.read-prompt.outputs.content }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,35 @@
+name: Autonomous Review
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'autonomous-review'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        with:
+          model: google/gemini-2.0-flash
+          prompt: |
+            Review the open PR linked to issue #${{ github.event.issue.number }}.
+
+            Check that:
+            1. The implementation matches the issue requirements
+            2. Tests exist and cover the new behaviour
+            3. The full test suite passes
+
+            Post a comment on the PR summarising your findings. Flag any
+            gaps between the issue requirements and what was implemented.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -18,7 +18,26 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: anomalyco/opencode/github@latest
+      - name: Check for existing PR
+        id: check-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            const issueNumber = context.payload.issue.number;
+            const linked = prs.data.some(pr =>
+              pr.body && pr.body.includes(`#${issueNumber}`)
+            );
+            return linked;
+          result-encoding: string
+
+      - name: Implement
+        if: steps.check-pr.outputs.result == 'false'
+        uses: anomalyco/opencode/github@latest
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
@@ -35,3 +54,16 @@ jobs:
             Project context is in CLAUDE.md. Tests live in tests/unit/ and
             tests/integration/. Run tests with:
               .venv/bin/pytest tests/unit/ tests/integration/
+
+      - name: Validate existing PR
+        if: steps.check-pr.outputs.result == 'true'
+        uses: anomalyco/opencode/github@latest
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        with:
+          model: google/gemini-2.0-flash
+          prompt: |
+            A PR already exists for this issue. Review the open PR linked
+            to issue #${{ github.event.issue.number }}. Check that the
+            implementation matches the issue requirements and the tests
+            pass. Post a comment on the PR summarising your findings.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,37 @@
+name: Autonomous Feature Agent
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'autonomous'
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        with:
+          model: google/gemini-2.0-flash
+          prompt: |
+            Implement the feature described in this GitHub issue.
+
+            Follow the TDD workflow strictly:
+            1. Write failing tests first that describe the intended behavior
+            2. Implement the minimum code to make the tests pass
+            3. Verify the full test suite is green
+            4. Open a PR linked to this issue
+
+            Project context is in CLAUDE.md. Tests live in tests/unit/ and
+            tests/integration/. Run tests with:
+              .venv/bin/pytest tests/unit/ tests/integration/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,23 @@ Always invoke `test-writer` before `code-builder`. Tests come first.
 
 The `qa` agent starts the webapp (if not already running) and uses Playwright to verify each behavior in the live browser, including screenshots. It runs after `code-reviewer`. Server start command: `TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload`. Auth bypass: `GET /auth/test-login` (only available when `TEST_MODE=true`).
 
+## Autonomous GitHub Agent
+
+Issues can be implemented automatically without human involvement by applying labels:
+
+- `autonomous` — triggers the implementation workflow: the agent reads the issue, follows the TDD workflow above, and opens a PR named `auto/issue-{N}` with `Closes #N` in the body
+- `autonomous-review` — triggers the review workflow: the agent checks the open PR linked to the issue and posts its findings as a PR comment
+
+**Abort behaviour:** if `autonomous` is applied to an issue that already has an open PR, the workflow aborts and posts a comment on the issue explaining why, with a pointer to use `autonomous-review` instead.
+
+**Key files:**
+- `.github/workflows/opencode-implement.yml` — implementation workflow (CI orchestration only)
+- `.github/workflows/opencode-review.yml` — review workflow (CI orchestration only)
+- `.github/prompts/implement.md` — agent instructions for implementation (edit this to tune behaviour)
+- `.github/prompts/review.md` — agent instructions for review (edit this to tune behaviour)
+
+**Required GitHub secret:** `GOOGLE_API_KEY` — free API key from Google AI Studio. Model: `google/gemini-2.5-flash`.
+
 ## /tdd Command
 
 `/tdd` runs a strict red-green-refactor TDD cycle, orchestrating `test-writer`, `test-runner`, `code-builder`, and `code-reviewer` in sequence for each behavior.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,20 @@ If `playwright` is not found, make sure your venv is active (`source .venv/bin/a
 - Document assumptions and decisions
 - When in doubt, ask before refactoring shared code
 
+### Autonomous implementation
+
+Issues can be implemented automatically by the AI agent — no manual triggering required.
+
+1. Create a GitHub issue describing the feature or bug fix clearly
+2. Apply the `autonomous` label — the agent will pick it up, follow TDD, and open a PR
+
+If the issue already has an open PR and you apply `autonomous` by mistake, the agent will abort and post a comment explaining why. Apply `autonomous-review` instead to have the agent check the existing PR against the issue requirements and post its findings.
+
+**Tips for writing good autonomous issues:**
+- Be specific about the expected behaviour, not just the goal
+- Reference relevant files or functions if you know them
+- Include acceptance criteria where possible — the agent uses these to validate its own work
+
 ---
 
 ## Project Status


### PR DESCRIPTION
## Summary

Adds two autonomous agent workflows triggered by labels on GitHub issues.

- **`autonomous`** → `opencode-implement.yml` — implements the feature following TDD and opens a PR. If an open PR already exists for the issue, aborts and posts a comment pointing to `autonomous-review` instead.
- **`autonomous-review`** → `opencode-review.yml` — reviews the existing PR linked to the issue, checks it meets the requirements, and posts findings as a PR comment.

Both workflows use `google/gemini-2.0-flash` via `GOOGLE_API_KEY` (free tier, no personal Anthropic account required).

Closes #29

## Setup required before merging

- [ ] Add `GOOGLE_API_KEY` secret (Settings → Secrets → Actions)
- [ ] Create the `autonomous` label
- [ ] Create the `autonomous-review` label

## Test plan

- [ ] Apply a non-`autonomous` label to an issue — confirm neither workflow fires
- [ ] Apply `autonomous` to a fresh issue — confirm implementation runs and a PR is opened
- [ ] Apply `autonomous` to an issue that already has an open PR — confirm the workflow aborts and posts a comment
- [ ] Apply `autonomous-review` to an issue with an open PR — confirm the agent reviews and comments on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)