### PR TITLE
Pass GITHUB_TOKEN explicitly to OpenCode action

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -59,6 +59,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash
           prompt: ${{ steps.read-prompt.outputs.content }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash
           prompt: ${{ steps.read-prompt.outputs.content }}


### PR DESCRIPTION
## Summary

- Adds `GITHUB_TOKEN: ${{ github.token }}` to the env block on both OpenCode steps
- `use_github_token: true` alone is not enough — the token must also be explicitly set in env or OpenCode errors with `GITHUB_TOKEN environment variable is not set`

## Test plan

- [ ] Merge and re-trigger by removing and re-adding the `autonomous` label to issue #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)