### PR TITLE
Fix Google API key env var name for OpenCode

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.check-pr.outputs.pr_exists == 'false'
         uses: anomalyco/opencode/github@latest
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: anomalyco/opencode/github@latest
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash


### PR DESCRIPTION
## Summary

- Renames `GOOGLE_API_KEY` to `GOOGLE_GENERATIVE_AI_API_KEY` in both workflow env blocks
- OpenCode's Google provider looks for `GOOGLE_GENERATIVE_AI_API_KEY` specifically — `GOOGLE_API_KEY` is silently ignored
- The GitHub secret name is unchanged; just mapped to the correct variable name

## Test plan

- [ ] Merge and re-trigger by removing and re-adding the `autonomous` label to issue #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)