### PR TITLE
Fix PR detection false positive and API key env var

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -29,8 +29,9 @@ jobs:
               state: 'open'
             });
             const issueNumber = context.payload.issue.number;
+            const closingPattern = new RegExp(`(closes|fixes|resolves)\\s+#${issueNumber}\\b`, 'i');
             const linked = prs.data.find(pr =>
-              pr.body && pr.body.includes(`#${issueNumber}`)
+              pr.body && closingPattern.test(pr.body)
             );
             if (linked) {
               await github.rest.issues.createComment({
@@ -58,7 +59,7 @@ jobs:
         if: steps.check-pr.outputs.pr_exists == 'false'
         uses: anomalyco/opencode/github@latest
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -40,6 +40,10 @@ jobs:
                 issue_number: issueNumber,
                 body: `⚠️ Implementation aborted — [PR #${linked.number}](${linked.html_url}) already exists for this issue. Apply the \`autonomous-review\` label to validate it instead.`
               });
+              await core.summary
+                .addHeading('⚠️ Implementation skipped')
+                .addRaw(`Open PR <a href="${linked.html_url}">#${linked.number}</a> already exists for issue #${issueNumber}. Apply <code>autonomous-review</code> to validate it instead.`)
+                .write();
               core.setOutput('pr_exists', 'true');
             } else {
               core.setOutput('pr_exists', 'false');

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: anomalyco/opencode/github@latest
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash


### PR DESCRIPTION
## Summary

Two fixes in one:

**1. PR detection false positive**
The check was matching any open PR with `#24` anywhere in the body — including our own fix PRs that mentioned issue #24 in their test plans. Now uses `Closes/Fixes/Resolves #N` pattern matching, which is the conventional GitHub issue-linking syntax that an autonomous PR would use.

**2. Google API key env var name**
Renamed `GOOGLE_API_KEY` → `GOOGLE_GENERATIVE_AI_API_KEY` to match the renamed secret and what OpenCode's Google provider expects.

## Test plan

- [ ] Merge and re-trigger by removing and re-adding the `autonomous` label to issue #24
- [ ] Confirm the workflow proceeds past the PR check and OpenCode starts working

🤖 Generated with [Claude Code](https://claude.com/claude-code)