### PR TITLE
Configure git identity before OpenCode runs

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -49,6 +49,12 @@ jobs:
               core.setOutput('pr_exists', 'false');
             }
 
+      - name: Configure git identity
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        run: |
+          git config --global user.email "autonomous-agent@github-actions"
+          git config --global user.name "Autonomous Agent"
+
       - name: Read prompt
         id: read-prompt
         if: steps.check-pr.outputs.pr_exists == 'false'

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -75,3 +75,4 @@ jobs:
           model: google/gemini-2.5-flash
           prompt: ${{ steps.read-prompt.outputs.content }}
           use_github_token: true
+          share: true

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -76,3 +76,15 @@ jobs:
           prompt: ${{ steps.read-prompt.outputs.content }}
           use_github_token: true
           share: true
+
+      - name: Notify failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `❌ Implementation failed — [view the Actions run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
+            });


### PR DESCRIPTION
## Summary

Adds a `git config` step before OpenCode runs to set `user.email` and `user.name`. Without this, git commit fails with exit code 128 ("Author identity unknown") after OpenCode makes changes.

**Good news from the last run:** OpenCode understood issue #24, made the correct fix to `docker-compose.langfuse.yml`, and got all the way to committing before hitting this error. This should be the last blocker.

## Test plan

- [ ] Merge and re-trigger by removing and re-adding the `autonomous` label to issue #24
- [ ] Confirm a PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)