### PR TITLE
Wire Doppler into opencode-implement.yml for secret management

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -65,11 +65,24 @@ jobs:
           echo "$content" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Install Doppler CLI
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        uses: dopplerhq/cli-action@v4
+
+      - name: Fetch secrets from Doppler
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        run: |
+          LINE=$(doppler secrets download --no-file --format docker --project qsent --config dev | grep '^GOOGLE_GENERATIVE_AI_API_KEY=')
+          VALUE="${LINE#*=}"
+          echo "::add-mask::$VALUE"
+          echo "$LINE" >> "$GITHUB_ENV"
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
       - name: Implement
         if: steps.check-pr.outputs.pr_exists == 'false'
         uses: anomalyco/opencode/github@latest
         env:
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash


### PR DESCRIPTION
Closes #43

## Summary

The "Implement" step now receives `GOOGLE_GENERATIVE_AI_API_KEY` via Doppler (project `qsent`, config `dev`) instead of a raw GitHub secret, using a scoped read-only `DOPPLER_TOKEN`.

The secret is extracted using the technique documented on Doppler's own CLI docs (`--format docker` + `grep`) since no `--secrets`-name filter flag exists on `doppler secrets download`. The extracted value is explicitly masked with `::add-mask::` before being written to `$GITHUB_ENV`, so it won't appear in plaintext in Actions logs even if a later step fails verbosely or debug logging is enabled.

The model (`google/gemini-2.5-flash`) and trigger (`autonomous` label) are unchanged — this PR only changes where the secret value comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)