### PR TITLE
Stop implement.md from managing its own git branch/PR

### DIFF
--- a/.github/prompts/implement.md
+++ b/.github/prompts/implement.md
@@ -27,7 +27,21 @@ sections cited below apply to this single-pass run.
 7. Reconcile CLAUDE.md only if required — see "CLAUDE.md Reconciliation
    Gating Rule" in docs/TDD_AUTONOMOUS_POLICY.md; otherwise skip this step
    entirely.
-8. Open a PR linked to this issue.
+
+Do not create a branch, commit, push, or open a PR yourself. The workflow
+wrapper that runs this session owns all of that: it pre-creates a branch
+before this session starts, and once this session ends, it checks whether
+the working tree is dirty and, if so, commits, pushes, and opens the PR
+automatically. Just implement the change and leave the changes uncommitted
+in the working tree.
+
+Note: the wrapper's PR creation has no documented way to customize the PR
+title or body, so the resulting PR body will be minimal and auto-generated
+by the wrapper rather than following the "PR Body Template Structure" in
+docs/TDD_AUTONOMOUS_POLICY.md (Plan, Behaviors Implemented, Files Changed,
+QA Results, Test Plan). That richer structure no longer applies to this
+workflow's PRs unless a different mechanism to feed the wrapper a custom
+body is found later.
 
 If any retry cap above is exhausted, or a precondition can't be resolved
 automatically (e.g. a test passes when it should still be failing), follow
@@ -36,10 +50,11 @@ diagnostics, and do not proceed to any later step. This run has no state
 file and does not resume — here, following the Failure Protocol just means
 terminating the workflow instead of continuing.
 
-Branch naming: create a branch named auto/issue-$ISSUE_NUMBER.
-
-PR body must include "Closes #$ISSUE_NUMBER" so the issue closes
-automatically on merge and the PR can be detected by other workflows.
+Your final summary should state "Closes #$ISSUE_NUMBER" so the intent is
+visible in the run output and logs, but note that you are not the one
+opening the PR — the wrapper is — so this text will not automatically
+appear in the PR body unless the wrapper is later configured to source it
+from your output.
 
 Project context is in CLAUDE.md. Tests live in tests/unit/ and
 tests/integration/. Run tests with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ The `qa` agent starts the webapp (if not already running) and uses Playwright to
 
 Issues can be implemented automatically without human involvement by applying labels:
 
-- `autonomous` — triggers the implementation workflow: the agent reads the issue, follows the TDD workflow above, and opens a PR named `auto/issue-{N}` with `Closes #N` in the body
+- `autonomous` — triggers the implementation workflow: the agent reads the issue and follows the TDD workflow above; the workflow wrapper (not the agent) then commits, pushes, and opens the PR itself if the working tree is dirty when the session ends, using its own `opencode/issue{N}-{timestamp}` branch naming
 - `autonomous-review` — triggers the review workflow: the agent checks the open PR linked to the issue and posts its findings as a PR comment
 
 **Abort behaviour:** if `autonomous` is applied to an issue that already has an open PR, the workflow aborts and posts a comment on the issue explaining why, with a pointer to use `autonomous-review` instead.


### PR DESCRIPTION
## Summary
- Removes the branch-naming and "open a PR" instructions from `.github/prompts/implement.md`, since the `anomalyco/opencode/github@latest` action wrapper already owns branch creation, commit, push, and PR creation based on tree-dirty state after the agent's session ends. The agent instructing itself to create a competing branch caused the wrapper's push/PR step to bail out silently, so recent autonomous runs wrote correct code but never opened a PR.
- Rephrases the "Closes #N" requirement as guidance for the agent's final summary rather than an instruction to open a PR itself.
- Flags a known regression: the wrapper has no documented way to customize the PR title/body (confirmed against https://opencode.ai/docs/github/), so PRs from this workflow will now get a minimal auto-generated body instead of the richer template in `docs/TDD_AUTONOMOUS_POLICY.md` ("PR Body Template Structure"), unless a different mechanism is found later.
- Updates `CLAUDE.md`'s description of the `autonomous` label to reflect the wrapper's actual `opencode/issue{N}-{timestamp}` branch naming instead of the old `auto/issue-{N}` convention.

## Test plan
- [ ] Apply the `autonomous` label to a test issue and confirm the wrapper opens a PR (not just writes code) using its own branch name
- [ ] Confirm the `autonomous-review` / abort-behaviour duplicate-PR detection still works given the wrapper's auto-generated PR body (flagged as an open question, not fixed in this PR)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)