### PR TITLE
Fix git push authentication and add job timeout to opencode-implement.yml

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -8,6 +8,7 @@ jobs:
   implement:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'autonomous'
+    timeout-minutes: 20
     permissions:
       id-token: write
       contents: write
@@ -55,6 +56,11 @@ jobs:
           git config --global user.email "autonomous-agent@github-actions"
           git config --global user.name "Autonomous Agent"
 
+      - name: Configure git push authentication
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        run: |
+          git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+
       - name: Read prompt
         id: read-prompt
         if: steps.check-pr.outputs.pr_exists == 'false'
@@ -91,7 +97,7 @@ jobs:
           share: true
 
       - name: Notify failure
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -8,7 +8,7 @@ jobs:
   implement:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'autonomous'
-    timeout-minutes: 20
+    timeout-minutes: 35
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary

- Adds a "Configure git push authentication" step that sets the `origin` remote URL with an embedded `x-access-token` using `${{ github.token }}` and `${{ github.repository }}`, before the third-party `anomalyco/opencode/github@latest` action runs. Fixes the push failure (`fatal: could not read Username for 'https://github.com'`) caused by `persist-credentials: false` on checkout leaving no credential configured for the plain `git push` that action performs internally.
- Adds `timeout-minutes: 20` to the `implement` job to cap runaway retry storms. A prior run (issue #46, run 29625374170) spent ~5.5 hours retrying against a Gemini free-tier 429 quota error before the actual implementation work ran in under 30 seconds.
- Changes the "Notify failure" step's condition from `if: failure()` to `if: failure() || cancelled()`. A job that hits `timeout-minutes` is marked `cancelled`, not `failed` — without this change the new timeout would silently cut the job off with no comment posted to the issue.

## Investigation notes

- Checked `anomalyco/opencode` (the third-party action's source) for a `maxRetries`/retry-ceiling config that could fail fast on 429s instead of relying solely on the job timeout. Found no such option exposed in `github/action.yml`, `github/index.ts`, or the internal retry utility (`packages/core/src/util/retry.ts`) — nothing documented or configurable. `timeout-minutes` is the only backstop available.
- Checked `opencode-review.yml` for the same push-auth issue: it only reads and comments (`permissions: contents: read`, no push step), so the fix doesn't apply there.
- Considered flipping `persist-credentials: false` to `true` on checkout instead (lets `actions/checkout` configure git credentials via `http.extraheader` automatically, without writing the token into the remote URL in plaintext). Kept the explicit `git remote set-url` approach per the issue's request; either works, and `github.token` is auto-masked in Actions logs regardless of where it appears, so there's no meaningful log-leak risk either way.

Closes #54

## Test plan

- [ ] YAML validated with `python -c "import yaml; yaml.safe_load(open(...))"` (passed locally)
- [ ] Trigger the `autonomous` label workflow on a real issue and confirm the push/PR-creation step succeeds
- [ ] Confirm a forced timeout (or code review) validates the `cancelled()` branch posts the failure comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)