### PR TITLE
Remove load_dotenv() from main.py in favor of doppler run for local dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,11 @@ The longer-term vision is a full AI forecasting system with backtesting. A `Fore
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
-# Run server (normal — requires Google OAuth credentials in .env)
-.venv/bin/uvicorn qsf.api.main:app --reload
+# Run server (normal — requires doppler login && doppler setup done once; Google OAuth credentials come from Doppler)
+doppler run -- .venv/bin/uvicorn qsf.api.main:app --reload
 
 # Run server (test mode — bypasses Google auth)
-TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload
+TEST_MODE=true doppler run -- .venv/bin/uvicorn qsf.api.main:app --reload
 
 # Run all fast tests
 .venv/bin/pytest tests/unit/ tests/integration/
@@ -112,7 +112,7 @@ app.dependency_overrides[get_current_user] = lambda: MOCK_USER
 
 **QA/E2E bypass (TEST_MODE only):**
 ```bash
-TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload
+TEST_MODE=true doppler run -- .venv/bin/uvicorn qsf.api.main:app --reload
 # Then visit http://localhost:8000/auth/test-login once to get a session cookie
 ```
 
@@ -149,7 +149,7 @@ When implementing a feature or fixing a bug, invoke agents in this order:
 
 Always invoke `test-writer` before `code-builder`. Tests come first.
 
-The `qa` agent starts the webapp (if not already running) and uses Playwright to verify each behavior in the live browser, including screenshots. It runs after `code-reviewer`. Server start command: `TEST_MODE=true .venv/bin/uvicorn qsf.api.main:app --reload`. Auth bypass: `GET /auth/test-login` (only available when `TEST_MODE=true`).
+The `qa` agent starts the webapp (if not already running) and uses Playwright to verify each behavior in the live browser, including screenshots. It runs after `code-reviewer`. Server start command: `TEST_MODE=true doppler run -- .venv/bin/uvicorn qsf.api.main:app --reload`. Auth bypass: `GET /auth/test-login` (only available when `TEST_MODE=true`).
 
 **Verify outcomes, not just status:** when a task involves a CI workflow, automation, or any process with an expected end state (a PR opened, a file created, a deployment completed), confirm that end state actually exists rather than relying solely on an exit code or "succeeded" status.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Start Langfuse locally (requires Docker):
 docker compose -f docker-compose.langfuse.yml up -d
 ```
 
-Then open http://localhost:3000, sign up, create a project, and copy the API keys into `.env`:
+Then open http://localhost:3000, sign up, create a project, and set the API keys in Doppler (`qsent` project, `dev` config):
 
 ```
 LANGFUSE_PUBLIC_KEY=<your public key>
@@ -267,7 +267,7 @@ To log out, visit `http://localhost:8000/auth/logout`.
 To skip Google SSO when testing locally, start the server with `TEST_MODE=true`:
 
 ```bash
-TEST_MODE=true uvicorn qsf.api.main:app --reload
+TEST_MODE=true doppler run -- uvicorn qsf.api.main:app --reload
 ```
 
 Then visit `http://localhost:8000/auth/test-login` once — it sets a session cookie and drops you straight into the app. This route is only registered when `TEST_MODE=true` and is never available in production.
@@ -297,13 +297,14 @@ pip install -e ".[dev]"
 
 ### 2. Set up environment variables
 
-Copy the example file and fill in your keys:
+The app no longer reads `.env` directly — secrets are injected at process launch via [Doppler](https://www.doppler.com). One-time setup:
 
 ```bash
-cp .env.example .env
+doppler login
+doppler setup   # select the qsent project, dev config
 ```
 
-Required keys:
+`.env.example` still documents the variable names the app expects, for reference if you need to add a new one in Doppler:
 ```
 # Google OAuth (see Authentication section above)
 GOOGLE_CLIENT_ID=
@@ -330,7 +331,7 @@ To get `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`, create an OAuth 2.0 client
 ### 3. Start the server
 
 ```bash
-uvicorn qsf.api.main:app --reload
+doppler run -- uvicorn qsf.api.main:app --reload
 ```
 
 The `--reload` flag restarts the server automatically when you edit source files.
@@ -381,7 +382,7 @@ E2E tests (Playwright) must be run manually on your local machine — they requi
 playwright install chromium
 
 # Terminal 1: start the server with test mode enabled
-TEST_MODE=true uvicorn qsf.api.main:app --reload
+TEST_MODE=true doppler run -- uvicorn qsf.api.main:app --reload
 
 # Terminal 2: run E2E tests
 pytest tests/e2e/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "praw>=7.7",
     "pandas>=2.0",
     "requests>=2.31",
-    "python-dotenv>=1.0",
     "langgraph>=0.2",
     "openai>=1.0",
     "httpx>=0.27",

--- a/src/qsf/api/main.py
+++ b/src/qsf/api/main.py
@@ -2,24 +2,20 @@ import time
 import uuid
 from pathlib import Path
 
-from dotenv import load_dotenv
+import httpx
+import structlog
+import structlog.contextvars
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response, StreamingResponse
+from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
 
-load_dotenv()  # Must run before auth is imported so env vars are populated
-
-import httpx  # noqa: E402
-import structlog  # noqa: E402
-import structlog.contextvars  # noqa: E402
-from fastapi import Depends, FastAPI, HTTPException, Query, Request  # noqa: E402
-from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
-from fastapi.responses import FileResponse, Response, StreamingResponse  # noqa: E402
-from pydantic import BaseModel  # noqa: E402
-from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
-
-from qsf.agents.news_comparison import run_news_comparison, run_news_comparison_stream  # noqa: E402
-from qsf.agents.workflow import pipeline  # noqa: E402
-from qsf.api.auth import COOKIE_NAME, decode_session_token, get_current_user  # noqa: E402
-from qsf.api.auth import router as auth_router  # noqa: E402
-from qsf.common.logging import configure_logging, flush_langfuse, get_langfuse, set_current_trace, get_logger  # noqa: E402
+from qsf.agents.news_comparison import run_news_comparison, run_news_comparison_stream
+from qsf.agents.workflow import pipeline
+from qsf.api.auth import COOKIE_NAME, decode_session_token, get_current_user
+from qsf.api.auth import router as auth_router
+from qsf.common.logging import configure_logging, flush_langfuse, get_langfuse, set_current_trace, get_logger
 
 configure_logging()
 


### PR DESCRIPTION
Closes #60

## Summary

Doppler now owns environment population for local dev. `load_dotenv()` and the `python-dotenv` dependency are removed since they became dead weight once `doppler run` injects the same variables at process launch. README.md and CLAUDE.md are updated to document `doppler run` as the new local dev workflow (including the `doppler login` / `doppler setup` one-time prerequisite). `.env.example` is kept as-is, as a reference for the variable names Doppler needs — it's no longer copied to a real `.env` for the app to read.

## Test plan

- [x] `.venv/bin/pytest tests/unit/ tests/integration/` — 175 passed
- [x] Verified import order in `src/qsf/api/main.py` is unchanged aside from removing the `load_dotenv` lines and the now-stale `# noqa: E402` markers
- [x] Started the server with `TEST_MODE=true doppler run -- .venv/bin/uvicorn qsf.api.main:app --reload` and confirmed `GET /health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)