### PR TITLE
Add per-source status breakdown for pipeline failures instead of raw 500s

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -6,6 +6,9 @@
 
 - Authenticated user sees app
 - Analyze renders chart
+- Analyze shows error table on failure
+- Analyze error table renders provider message as literal text
+- Analyze shows stringified detail when source status missing
 - Logout redirects to login
 - Profile button is visible
 - Profile dropdown opens on click
@@ -24,6 +27,7 @@
 - Health
 - Analyze valid ticker
 - Analyze returns 404 on error
+- Analyze error response includes source status
 - Analyze missing ticker
 - Analyze ticker is uppercased
 

--- a/index.html
+++ b/index.html
@@ -60,6 +60,15 @@
     }
     .meta span b { color: #fff; }
 
+    .error-card { width: 100%; max-width: 960px; background: #1c1f2e; border-radius: 12px; padding: 1.5rem; }
+    .error-heading { font-size: 1.1rem; color: #fff; margin-bottom: 1rem; }
+    .status-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+    .status-table td { padding: 0.5rem 0; border-bottom: 1px solid #2e3250; }
+    .status-table td.status-label { color: #aaa; width: 160px; }
+    .status-value.status-ok { color: #4caf7d; }
+    .status-value.status-skipped { color: #888; }
+    .status-value.status-error { color: #f76c6c; }
+
     header {
       position: relative;
       width: 100%;
@@ -160,6 +169,13 @@
 
   <div id="status"></div>
 
+  <div class="error-card" id="errorSection" style="display:none">
+    <h2 class="error-heading">Oops, something went wrong</h2>
+    <table class="status-table">
+      <tbody id="statusTableBody"></tbody>
+    </table>
+  </div>
+
   <div class="chart-wrapper" id="chartSection" style="display:none">
     <div class="meta" id="meta"></div>
     <canvas id="chart"></canvas>
@@ -222,6 +238,7 @@
       btn.disabled = true;
       status.textContent = `Fetching data for ${ticker}...`;
       document.getElementById("chartSection").style.display = "none";
+      document.getElementById("errorSection").style.display = "none";
 
       try {
         const res = await fetch("/analyze", {
@@ -236,18 +253,69 @@
             window.location.href = "/login.html";
             return;
           }
-          const err = await res.json();
-          status.textContent = `Error: ${err.detail || res.statusText}`;
+
+          const err = await res.json().catch(() => null);
+          const detail = err?.detail;
+
+          if (detail && typeof detail === "object" && detail.source_status) {
+            document.getElementById("chartSection").style.display = "none";
+            status.textContent = "";
+            renderStatusTable(detail.source_status);
+            document.getElementById("errorSection").style.display = "block";
+            return;
+          }
+
+          status.textContent = `Error: ${detail || res.statusText}`;
           return;
         }
 
         const data = await res.json();
         renderChart(data);
         status.textContent = "";
+        document.getElementById("errorSection").style.display = "none";
       } catch (e) {
         status.textContent = `Failed to connect to API: ${e.message}`;
       } finally {
         btn.disabled = false;
+      }
+    }
+
+    function renderStatusTable(sourceStatus) {
+      const sources = [
+        { key: "market", label: "Market Data" },
+        { key: "news", label: "News" },
+        { key: "reddit", label: "Reddit / Social" },
+        { key: "sentiment", label: "Sentiment Scoring" },
+      ];
+
+      const body = document.getElementById("statusTableBody");
+      body.textContent = "";
+
+      for (const { key, label } of sources) {
+        const value = sourceStatus[key] ?? "skipped";
+        let text = value;
+        let cls = "status-error";
+        if (value === "ok") {
+          text = "OK";
+          cls = "status-ok";
+        } else if (value === "skipped") {
+          text = "Skipped";
+          cls = "status-skipped";
+        }
+
+        const row = document.createElement("tr");
+        row.dataset.source = key;
+
+        const labelCell = document.createElement("td");
+        labelCell.className = "status-label";
+        labelCell.textContent = label;
+
+        const valueCell = document.createElement("td");
+        valueCell.className = `status-value ${cls}`;
+        valueCell.textContent = text;
+
+        row.append(labelCell, valueCell);
+        body.appendChild(row);
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -265,7 +265,10 @@
             return;
           }
 
-          status.textContent = `Error: ${detail || res.statusText}`;
+          const message = typeof detail === "string" || !detail
+            ? detail || res.statusText
+            : JSON.stringify(detail);
+          status.textContent = `Error: ${message}`;
           return;
         }
 

--- a/src/qsf/agents/workflow.py
+++ b/src/qsf/agents/workflow.py
@@ -4,8 +4,9 @@ LangGraph pipeline for sentiment analysis.
 Graph:
     fetch_market_data → fetch_news → fetch_reddit → score_sentiment → aggregate
 """
+import operator
 from datetime import datetime
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 from typing_extensions import TypedDict
 
 import pandas as pd
@@ -30,6 +31,7 @@ class PipelineState(TypedDict, total=False):
     scored_items: list
     result: Optional[dict]
     error: Optional[str]
+    source_status: Annotated[dict[str, str], operator.or_]
 
 
 def build_pipeline(
@@ -42,10 +44,16 @@ def build_pipeline(
         ticker = state["ticker"]
         trace = get_current_trace()
         span = trace.span(name="fetch_market_data", input={"ticker": ticker}) if trace else None
-        hist = market.get_history(ticker, "30d")
+        try:
+            hist = market.get_history(ticker, "30d")
+        except Exception as e:
+            msg = f"Failed to fetch market data: {e}"
+            if span: span.end(output={"error": str(e)}, level="ERROR")
+            return {"error": msg, "source_status": {"market": msg}}
         if hist.empty:
+            msg = f"No price data found for '{ticker}'"
             if span: span.end(output={"error": "no price data"}, level="ERROR")
-            return {"error": f"No price data found for '{ticker}'"}
+            return {"error": msg, "source_status": {"market": msg}}
         stock_df = hist[["Close", "Volume"]].copy()
         stock_df.index = stock_df.index.date
         stock_df["ror"] = stock_df["Close"].pct_change() * 100
@@ -56,20 +64,30 @@ def build_pipeline(
                 "[%s] fetch_market_data: only %d trading days returned, expected ~21",
                 ticker, days,
             )
-        raw_name = market.get_company_name(ticker)
+        try:
+            raw_name = market.get_company_name(ticker)
+        except Exception as e:
+            msg = f"Failed to fetch market data: {e}"
+            if span: span.end(output={"error": str(e)}, level="ERROR")
+            return {"error": msg, "source_status": {"market": msg}}
         company_name = company_search_name(raw_name)
         logger.info("[%s] fetch_market_data: company name resolved to '%s'", ticker, company_name)
         if span: span.end(output={"trading_days": days, "company_name": company_name})
-        return {"stock_df": stock_df, "company_name": company_name}
+        return {"stock_df": stock_df, "company_name": company_name, "source_status": {"market": "ok"}}
 
     def _fetch_news(state: dict) -> dict:
         if state.get("error"):
-            return {}
+            return {"source_status": {"news": "skipped"}}
         ticker = state["ticker"]
         company_name = state.get("company_name", "")
         trace = get_current_trace()
         span = trace.span(name="fetch_news", input={"ticker": ticker, "company_name": company_name}) if trace else None
-        news_items = news.get_articles(ticker, company_name)
+        try:
+            news_items = news.get_articles(ticker, company_name)
+        except Exception as e:
+            msg = f"Failed to fetch news data: {e}"
+            if span: span.end(output={"error": str(e)}, level="ERROR")
+            return {"error": msg, "source_status": {"news": msg}}
         count = len(news_items)
         logger.info("[%s] fetch_news: %d articles returned", ticker, count)
         if count == 0:
@@ -77,16 +95,21 @@ def build_pipeline(
         elif count < 5:
             logger.warning("[%s] fetch_news: only %d articles returned, sentiment coverage may be sparse", ticker, count)
         if span: span.end(output={"count": count})
-        return {"news_items": news_items}
+        return {"news_items": news_items, "source_status": {"news": "ok"}}
 
     def _fetch_reddit(state: dict) -> dict:
         if state.get("error"):
-            return {}
+            return {"source_status": {"reddit": "skipped"}}
         ticker = state["ticker"]
         company_name = state.get("company_name", "")
         trace = get_current_trace()
         span = trace.span(name="fetch_reddit", input={"ticker": ticker, "company_name": company_name}) if trace else None
-        reddit_items = social.get_posts(ticker, company_name)
+        try:
+            reddit_items = social.get_posts(ticker, company_name)
+        except Exception as e:
+            msg = f"Failed to fetch Reddit data: {e}"
+            if span: span.end(output={"error": str(e)}, level="ERROR")
+            return {"error": msg, "source_status": {"reddit": msg}}
         count = len(reddit_items)
         logger.info("[%s] fetch_reddit: %d posts returned", ticker, count)
         for item in reddit_items:
@@ -94,11 +117,11 @@ def build_pipeline(
         if count == 0:
             logger.warning("[%s] fetch_reddit: 0 posts returned — Reddit API may be unavailable or ticker has low social coverage", ticker)
         if span: span.end(output={"count": count})
-        return {"reddit_items": reddit_items}
+        return {"reddit_items": reddit_items, "source_status": {"reddit": "ok"}}
 
     def _score_sentiment(state: dict) -> dict:
         if state.get("error"):
-            return {}
+            return {"source_status": {"sentiment": "skipped"}}
         ticker = state["ticker"]
         news_items = state.get("news_items", [])
         reddit_items = state.get("reddit_items", [])
@@ -108,11 +131,17 @@ def build_pipeline(
             ticker, len(news_items), len(reddit_items), len(items),
         )
         if not items:
-            return {"error": f"No news or social data found for '{ticker}'"}
+            msg = f"No news or social data found for '{ticker}'"
+            return {"error": msg, "source_status": {"sentiment": msg}}
         trace = get_current_trace()
         span = trace.span(name="score_sentiment", input={"news": len(news_items), "social": len(reddit_items)}) if trace else None
         logger.info("[%s] score_sentiment: calling model.score on %d items", ticker, len(items))
-        scores = model.score([item["text"] for item in items])
+        try:
+            scores = model.score([item["text"] for item in items])
+        except Exception as e:
+            msg = f"Failed to score sentiment: {e}"
+            if span: span.end(output={"error": str(e)}, level="ERROR")
+            return {"error": msg, "source_status": {"sentiment": msg}}
         logger.info("[%s] score_sentiment: model.score returned", ticker)
         for idx, (item, score) in enumerate(zip(items, scores)):
             source_label = "news article" if item["source"] == "news" else "social post"
@@ -157,7 +186,7 @@ def build_pipeline(
                 ticker, mean_score,
             )
         if span: span.end(output={"scored": len(scored), "mean": round(mean_score, 4), "failed": len(items) - len(scored)})
-        return {"scored_items": scored}
+        return {"scored_items": scored, "source_status": {"sentiment": "ok"}}
 
     def _aggregate(state: dict) -> dict:
         if state.get("error"):

--- a/src/qsf/api/main.py
+++ b/src/qsf/api/main.py
@@ -103,7 +103,10 @@ def analyze(request: AnalyzeRequest, user: dict = Depends(get_current_user)):
     flush_langfuse()
 
     if state.get("error"):
-        raise HTTPException(status_code=404, detail=state["error"])
+        raise HTTPException(
+            status_code=404,
+            detail={"error": state["error"], "source_status": state.get("source_status", {})},
+        )
     return state["result"]
 
 

--- a/tests/e2e/test_app_flow.py
+++ b/tests/e2e/test_app_flow.py
@@ -139,6 +139,29 @@ def test_analyze_error_table_renders_provider_message_as_literal_text(page: Page
     assert page.locator('[data-source="market"] .status-value img').count() == 0
 
 
+def test_analyze_shows_stringified_detail_when_source_status_missing(page: Page, base_url: str):
+    """
+    Regression test: if /analyze ever returns a 404 with an object `detail`
+    that lacks a `source_status` key (a shape mismatch, not the normal
+    per-source error path), the status line must show readable JSON, never
+    the literal string "[object Object]".
+    """
+    page.route(
+        "**/analyze",
+        lambda route: route.fulfill(
+            status=404,
+            content_type="application/json",
+            body=json.dumps({"detail": {"error": "weird shape", "foo": "bar"}}),
+        ),
+    )
+    page.goto(base_url)
+    page.fill("#ticker", "IONQ")
+    page.click("#analyzeBtn")
+
+    expect(page.locator("#status")).not_to_have_text("Error: [object Object]")
+    expect(page.locator("#status")).to_contain_text("weird shape")
+
+
 def test_logout_redirects_to_login(page: Page, base_url: str):
     page.goto(f"{base_url}/auth/logout")
     page.wait_for_url(f"{base_url}/login.html", timeout=5000)

--- a/tests/e2e/test_app_flow.py
+++ b/tests/e2e/test_app_flow.py
@@ -58,6 +58,87 @@ def test_analyze_renders_chart(page: Page, base_url: str):
     expect(page.locator("#chartSection")).to_be_visible(timeout=5000)
 
 
+def test_analyze_shows_error_table_on_failure(page: Page, base_url: str):
+    """
+    NOTE: written pre-implementation — expected to fail (selectors below
+    don't exist yet) until code-builder adds the per-source error UI
+    (#errorSection, .error-heading, [data-source] .status-value) to
+    index.html and wires it to the /analyze 404 { detail: { error,
+    source_status } } response shape.
+
+    Requires a live server (TEST_MODE=true uvicorn ...) — not run by the
+    fast unit/integration suite.
+    """
+    page.route(
+        "**/analyze",
+        lambda route: route.fulfill(
+            status=404,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "detail": {
+                        "error": "Failed to fetch Reddit data: received 401 HTTP response",
+                        "source_status": {
+                            "market": "ok",
+                            "news": "ok",
+                            "reddit": "Failed to fetch Reddit data: received 401 HTTP response",
+                            "sentiment": "skipped",
+                        },
+                    }
+                }
+            ),
+        ),
+    )
+    page.goto(base_url)
+    page.fill("#ticker", "IONQ")
+    page.click("#analyzeBtn")
+
+    expect(page.locator("#errorSection")).to_be_visible(timeout=5000)
+    expect(page.locator("#errorSection .error-heading")).to_have_text("Oops, something went wrong")
+    expect(page.locator('[data-source="market"] .status-value')).to_have_text("OK")
+    expect(page.locator('[data-source="reddit"] .status-value')).to_contain_text(
+        "Failed to fetch Reddit data"
+    )
+    expect(page.locator("#chartSection")).not_to_be_visible()
+
+
+def test_analyze_error_table_renders_provider_message_as_literal_text(page: Page, base_url: str):
+    """
+    Regression test: source_status values come from third-party provider
+    exception messages (and can be influenced by the user-supplied ticker,
+    e.g. "No price data found for '<ticker>'"), so they must be rendered as
+    literal text, never parsed as HTML/executed as script.
+    """
+    payload_text = "<img src=x onerror=alert('xss')>"
+    page.route(
+        "**/analyze",
+        lambda route: route.fulfill(
+            status=404,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "detail": {
+                        "error": payload_text,
+                        "source_status": {
+                            "market": payload_text,
+                            "news": "skipped",
+                            "reddit": "skipped",
+                            "sentiment": "skipped",
+                        },
+                    }
+                }
+            ),
+        ),
+    )
+    page.goto(base_url)
+    page.fill("#ticker", "IONQ")
+    page.click("#analyzeBtn")
+
+    expect(page.locator("#errorSection")).to_be_visible(timeout=5000)
+    expect(page.locator('[data-source="market"] .status-value')).to_have_text(payload_text)
+    assert page.locator('[data-source="market"] .status-value img').count() == 0
+
+
 def test_logout_redirects_to_login(page: Page, base_url: str):
     page.goto(f"{base_url}/auth/logout")
     page.wait_for_url(f"{base_url}/login.html", timeout=5000)

--- a/tests/integration/test_analyze_endpoint.py
+++ b/tests/integration/test_analyze_endpoint.py
@@ -41,11 +41,47 @@ def test_analyze_valid_ticker(mock_pipeline):
 
 @patch("qsf.api.main.pipeline")
 def test_analyze_returns_404_on_error(mock_pipeline):
-    mock_pipeline.invoke.return_value = {"error": "No price data found for 'FAKE123'"}
+    # NOTE: written pre-implementation — `detail` becomes a dict (with
+    # "error" and "source_status" keys) once code-builder implements
+    # per-source status tracking. This test is expected to fail (KeyError
+    # on `["error"]`, since `detail` is currently a plain string) until then.
+    mock_pipeline.invoke.return_value = {
+        "error": "No price data found for 'FAKE123'",
+        "source_status": {
+            "market": "No price data found for 'FAKE123'",
+            "news": "skipped",
+            "reddit": "skipped",
+            "sentiment": "skipped",
+        },
+    }
 
     response = client.post("/analyze", json={"ticker": "FAKE123"})
     assert response.status_code == 404
-    assert "FAKE123" in response.json()["detail"]
+    assert "FAKE123" in response.json()["detail"]["error"]
+
+
+@patch("qsf.api.main.pipeline")
+def test_analyze_error_response_includes_source_status(mock_pipeline):
+    # NOTE: written pre-implementation — expected to fail until code-builder
+    # changes the /analyze 404 handler to return a dict `detail` containing
+    # both "error" and "source_status".
+    mock_pipeline.invoke.return_value = {
+        "error": "Failed to fetch Reddit data: received 401 HTTP response",
+        "source_status": {
+            "market": "ok",
+            "news": "ok",
+            "reddit": "Failed to fetch Reddit data: received 401 HTTP response",
+            "sentiment": "skipped",
+        },
+    }
+
+    response = client.post("/analyze", json={"ticker": "IONQ"})
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert "error" in detail
+    assert "source_status" in detail
+    assert isinstance(detail["source_status"], dict)
 
 
 def test_analyze_missing_ticker():

--- a/tests/unit/test_nodes.py
+++ b/tests/unit/test_nodes.py
@@ -238,3 +238,109 @@ class TestAggregate:
             (r["breakdown"]["news_sentiment"] + r["breakdown"]["social_sentiment"]) / 2, 4
         )
         assert r["sentiment_score"] == expected
+
+
+# ---------------------------------------------------------------------------
+# source_status
+#
+# NOTE: written pre-implementation — these tests are expected to FAIL until
+# code-builder adds the `source_status` field to PipelineState and wires
+# per-node try/except + status bookkeeping in workflow.py.
+# ---------------------------------------------------------------------------
+
+class TestSourceStatus:
+    def test_given_all_providers_succeed_when_pipeline_runs_then_all_sources_marked_ok(self):
+        market, news, social, model = make_providers()
+        pipeline = build_pipeline(market, news, social, model)
+        state = pipeline.invoke({"ticker": "IONQ"})
+        assert state["source_status"] == {
+            "market": "ok",
+            "news": "ok",
+            "reddit": "ok",
+            "sentiment": "ok",
+        }
+
+    def test_given_market_provider_raises_when_pipeline_runs_then_error_set_and_downstream_sources_skipped(self):
+        market, news, social, model = make_providers()
+        market.get_history.side_effect = Exception("connection timeout")
+        pipeline = build_pipeline(market, news, social, model)
+        state = pipeline.invoke({"ticker": "IONQ"})
+
+        assert state.get("error")
+
+        status = state["source_status"]
+        assert status["market"] != "ok"
+        assert isinstance(status["market"], str) and status["market"]
+        assert status["news"] == "skipped"
+        assert status["reddit"] == "skipped"
+        assert status["sentiment"] == "skipped"
+
+    def test_given_news_provider_raises_when_pipeline_runs_then_error_set_and_downstream_sources_skipped(self):
+        market, news, social, model = make_providers()
+        news.get_articles.side_effect = Exception("NewsAPI timeout")
+        pipeline = build_pipeline(market, news, social, model)
+        state = pipeline.invoke({"ticker": "IONQ"})
+
+        assert state.get("error")
+
+        status = state["source_status"]
+        assert status["market"] == "ok"
+        assert status["news"] != "ok"
+        assert isinstance(status["news"], str) and status["news"]
+        assert status["reddit"] == "skipped"
+        assert status["sentiment"] == "skipped"
+
+    def test_given_reddit_provider_raises_when_pipeline_runs_then_error_set_and_sentiment_skipped(self):
+        market, news, social, model = make_providers()
+        social.get_posts.side_effect = Exception("received 401 HTTP response")
+        pipeline = build_pipeline(market, news, social, model)
+        state = pipeline.invoke({"ticker": "IONQ"})
+
+        assert state.get("error")
+
+        status = state["source_status"]
+        assert status["market"] == "ok"
+        assert status["news"] == "ok"
+        assert status["reddit"] != "ok"
+        assert isinstance(status["reddit"], str)
+        assert "401" in status["reddit"]
+        assert status["sentiment"] == "skipped"
+
+    def test_given_sentiment_model_raises_when_pipeline_runs_then_error_set_and_sentiment_status_describes_failure(self):
+        market, news, social, model = make_providers()
+        model.score.side_effect = Exception("HuggingFace API down")
+        pipeline = build_pipeline(market, news, social, model)
+        state = pipeline.invoke({"ticker": "IONQ"})
+
+        assert state.get("error")
+
+        status = state["source_status"]
+        assert status["market"] == "ok"
+        assert status["news"] == "ok"
+        assert status["reddit"] == "ok"
+        assert status["sentiment"] != "ok"
+        assert isinstance(status["sentiment"], str) and status["sentiment"]
+
+    def test_given_empty_market_history_when_pipeline_runs_then_market_status_matches_error_and_downstream_skipped(self):
+        market, news, social, model = make_providers(history=pd.DataFrame())
+        pipeline = build_pipeline(market, news, social, model)
+        state = pipeline.invoke({"ticker": "FAKE"})
+
+        status = state["source_status"]
+        assert status["market"] == state["error"]
+        assert status["market"] not in ("ok", "skipped")
+        assert status["news"] == "skipped"
+        assert status["reddit"] == "skipped"
+        assert status["sentiment"] == "skipped"
+
+    def test_given_no_news_or_social_items_when_pipeline_runs_then_sentiment_status_matches_error(self):
+        market, news, social, model = make_providers(articles=[], posts=[], scores=[])
+        pipeline = build_pipeline(market, news, social, model)
+        state = pipeline.invoke({"ticker": "IONQ"})
+
+        status = state["source_status"]
+        assert status["market"] == "ok"
+        assert status["news"] == "ok"
+        assert status["reddit"] == "ok"
+        assert status["sentiment"] == state["error"]
+        assert status["sentiment"] not in ("ok", "skipped")


### PR DESCRIPTION
Closes #62

## Summary

Adds per-source status tracking to the LangGraph sentiment pipeline so a provider exception (e.g. Reddit auth failing with `prawcore.exceptions.ResponseException: received 401`) produces a clean, structured error instead of an unhandled 500 that broke the frontend's JSON parsing.

- **`PipelineState.source_status`**: a new `dict[str, str]` field, annotated `Annotated[dict[str, str], operator.or_]` so LangGraph unions each node's partial update instead of overwriting it with the last node's return value (verified this is load-bearing — see test plan).
- **Four nodes** (`_fetch_market_data`, `_fetch_news`, `_fetch_reddit`, `_score_sentiment`) each wrap their provider call(s) in try/except, recording `"ok"` / `"skipped"` / a descriptive error message per source. `_aggregate` is untouched (no external I/O, not one of the four tracked sources).
- **`/analyze`'s 404 response** now returns `detail: {error, source_status}` instead of a bare string, so the frontend can render a full breakdown rather than one generic line.
- **Frontend**: a new `#errorSection` card ("Oops, something went wrong" + a 4-row status table: Market Data / News / Reddit / Sentiment Scoring) replaces the old single-line error text, built via `createElement`/`textContent`.

## Security fix caught during self-review

The first draft of the frontend table used `innerHTML` template-string interpolation to build rows. Since `source_status` values are third-party provider exception text (and in some cases echo the raw user-supplied ticker, e.g. `"No price data found for '<ticker>'"`), that was a real DOM XSS vector — none of that content is developer-controlled. Fixed by switching to `createElement` + `textContent`, with a new e2e regression test asserting an `<img onerror=...>` payload renders as literal text with no `<img>` element created in the DOM.

This is the same bug class already tracked in #21 ("Fix innerHTML injection in renderChart (XSS risk)"), independently rediscovered here in a different function. Left a comment on #21 linking this PR as corroborating evidence and suggesting a priority bump, since this is now a second confirmed instance of the same pattern in production code: https://github.com/AIFS-daniel/qsent/issues/21#issuecomment-5079120472

## Test plan

- [x] `.venv/bin/pytest tests/unit/ tests/integration/` — 183 passed, including 7 new `TestSourceStatus` tests and 2 new/updated `/analyze` integration tests
- [x] `.venv/bin/pytest tests/e2e/` — 13 passed, including the error-table rendering test and the XSS regression test
- [x] Verified the `operator.or_` reducer is actually load-bearing: temporarily reverted it to a plain `dict[str, str]` and confirmed all 7 `TestSourceStatus` tests fail (`KeyError`) without it, then restored it and confirmed the suite is green again
- [x] Manually verified against this environment's real (currently misconfigured) Reddit credentials: `POST /analyze` for a real ticker now returns a clean `404` with `detail.source_status` populated, instead of a raw 500 plain-text crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Before changes: 
<img width="1438" height="366" alt="error handling_before" src="https://github.com/user-attachments/assets/eeafc921-5751-4ec8-9e67-bf057f840e76" />

After changes: 
<img width="1432" height="522" alt="error handling_after" src="https://github.com/user-attachments/assets/bae5c4a0-0acc-470c-9bcd-edcef34e3577" />
