### PR TITLE
Add concurrency group to opencode-implement.yml to prevent simultaneous duplicate runs

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled]
 
+concurrency:
+  group: opencode-implement-issue-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   implement:
     runs-on: ubuntu-latest

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled]
 
+concurrency:
+  group: opencode-review-issue-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #53

## Summary

Adds a `concurrency:` group to both `opencode-implement.yml` and `opencode-review.yml`, keyed on the issue number, with `cancel-in-progress: true` — so GitHub Actions itself enforces that only one run per issue can be active, instead of relying on the "Check for existing PR" guard (which can't detect a run that's currently in-flight but hasn't produced a PR yet).

- Each workflow gets its own group name (`opencode-implement-issue-<n>` / `opencode-review-issue-<n>`) so an implement run and a review run for the same issue don't cancel each other — only true duplicates of the *same* workflow for the same issue race and get cancelled.
- Placed at workflow level rather than job level: both workflows are single-job, so the two are functionally equivalent here, and workflow-level is the more idiomatic spot for "one run per key" semantics.
- `cancel-in-progress: true` per the issue's rationale: bounded retry caps mean a stuck run fails within minutes rather than hanging for hours, so the risk of cancelling a run that was about to succeed is low, and it matches the real use case (deliberately relabeling to force a clean retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)