### PR TITLE
Migrate opencode-review.yml to fetch GOOGLE_GENERATIVE_AI_API_KEY from Doppler

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -31,9 +31,20 @@ jobs:
           echo "$content" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v4
+
+      - name: Fetch secrets from Doppler
+        run: |
+          LINE=$(doppler secrets download --no-file --format docker --project qsent --config dev | grep '^GOOGLE_GENERATIVE_AI_API_KEY=')
+          VALUE="${LINE#*=}"
+          echo "::add-mask::$VALUE"
+          echo "$LINE" >> "$GITHUB_ENV"
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
       - uses: anomalyco/opencode/github@latest
         env:
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
           model: google/gemini-2.5-flash


### PR DESCRIPTION
Closes #65

## Summary
- Mirrors opencode-implement.yml's existing Doppler-fetch-and-mask pattern exactly: install the Doppler CLI, download the secret scoped to project qsent / config dev, explicitly mask it with `::add-mask::`, then write it to `$GITHUB_ENV`.
- Removes the direct `${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}` reference from the Review step's env block.
- No functional behavior change beyond the secret's source — same key, same value, same downstream usage.