### PR TITLE
Fix stale .env references in docs after Doppler migration

### DIFF
--- a/docs/decisions/006-observability-structlog-langfuse.md
+++ b/docs/decisions/006-observability-structlog-langfuse.md
@@ -67,4 +67,4 @@ To trace a specific user's activity: ask them to open `/auth/me` in their browse
 - Langfuse requires Docker to run locally (`docker compose -f docker-compose.langfuse.yml up -d`)
 - If `LANGFUSE_PUBLIC_KEY` is not set, tracing is silently disabled — the pipeline runs normally without it
 - `langfuse.flush()` is called after each pipeline invocation to ensure traces are sent before the HTTP response returns
-- Switching to Langfuse Cloud: change `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` in `.env`. No code changes required.
+- Switching to Langfuse Cloud: update `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` in Doppler (project `qsent`, `dev` config). No code changes required.

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -38,7 +38,8 @@ def test_set_and_get_current_trace_round_trip():
 
 def test_init_langfuse_returns_none_without_env_var(monkeypatch):
     # _init_langfuse() checks LANGFUSE_PUBLIC_KEY at call time, unlike the module-level
-    # singleton which is already initialized when .env is loaded before tests run.
+    # singleton which is already initialized from whatever env vars the process started
+    # with (e.g. via `doppler run`), not from a .env file — no such file is loaded for tests.
     monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
     from qsf.common.logging import _init_langfuse
     assert _init_langfuse() is None


### PR DESCRIPTION
Closes #67
Closes #45

## Summary

- `docs/decisions/006-observability-structlog-langfuse.md` told readers to switch Langfuse config by editing `.env`. Updated to describe setting `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` in Doppler (project `qsent`, `dev` config) instead.
- `tests/unit/test_observability.py:41` had a comment claiming the Langfuse singleton is initialized "when .env is loaded before tests run." No pytest-dotenv plugin is configured, so no `.env` file is ever loaded for tests — corrected the comment to reflect that the singleton picks up whatever env vars the process started with (e.g. via `doppler run`).

No functional or test-behavior changes — documentation and comment accuracy only.

This closes out the investigation from #45 (wire qsent's application runtime to Doppler). That investigation confirmed no other `.env` parsing or hardcoded secrets exist anywhere in the app, and every secret-bearing env var is present in Doppler's `qsent` project, `dev` config. These two doc references were the only remaining loose ends.

## Note: ci.yml is intentionally out of scope

`ci.yml`'s e2e job still pulls `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `SECRET_KEY` from native GitHub Actions secrets rather than Doppler. This is a deliberate, separate decision, not a staleness issue: `ci.yml` runs on every PR (far more frequently than the label-triggered autonomous workflows), and keeping it on GitHub's native secrets avoids adding a third-party CLI dependency to the most-frequently-run workflow, while preserving GitHub's well-understood secret isolation for a workflow that could eventually run against untrusted/fork PRs.

## Test plan

- [x] No functional code touched — diff is limited to a doc file and a comment
- [x] Existing test suite unaffected (comment-only change to test file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)