### PR TITLE
Rename autonomous label to autonomous-tdd throughout workflows and docs

### DIFF
--- a/.github/workflows/opencode-implement.yml
+++ b/.github/workflows/opencode-implement.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   implement:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'autonomous'
+    if: github.event.label.name == 'autonomous-tdd'
     timeout-minutes: 35
     permissions:
       id-token: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,10 +159,10 @@ The `qa` agent starts the webapp (if not already running) and uses Playwright to
 
 Issues can be implemented automatically without human involvement by applying labels:
 
-- `autonomous` — triggers the implementation workflow: the agent reads the issue and follows the TDD workflow above; the workflow wrapper (not the agent) then commits, pushes, and opens the PR itself if the working tree is dirty when the session ends, using its own `opencode/issue{N}-{timestamp}` branch naming
+- `autonomous-tdd` — triggers the implementation workflow: the agent reads the issue and follows the TDD workflow above; the workflow wrapper (not the agent) then commits, pushes, and opens the PR itself if the working tree is dirty when the session ends, using its own `opencode/issue{N}-{timestamp}` branch naming
 - `autonomous-review` — triggers the review workflow: the agent checks the open PR linked to the issue and posts its findings as a PR comment
 
-**Abort behaviour:** if `autonomous` is applied to an issue that already has an open PR, the workflow aborts and posts a comment on the issue explaining why, with a pointer to use `autonomous-review` instead.
+**Abort behaviour:** if `autonomous-tdd` is applied to an issue that already has an open PR, the workflow aborts and posts a comment on the issue explaining why, with a pointer to use `autonomous-review` instead.
 
 **Key files:**
 - `.github/workflows/opencode-implement.yml` — implementation workflow (CI orchestration only)

--- a/README.md
+++ b/README.md
@@ -405,9 +405,9 @@ If `playwright` is not found, make sure your venv is active (`source .venv/bin/a
 Issues can be implemented automatically by the AI agent — no manual triggering required.
 
 1. Create a GitHub issue describing the feature or bug fix clearly
-2. Apply the `autonomous` label — the agent will pick it up, follow TDD, and open a PR
+2. Apply the `autonomous-tdd` label — the agent will pick it up, follow TDD, and open a PR
 
-If the issue already has an open PR and you apply `autonomous` by mistake, the agent will abort and post a comment explaining why. Apply `autonomous-review` instead to have the agent check the existing PR against the issue requirements and post its findings.
+If the issue already has an open PR and you apply `autonomous-tdd` by mistake, the agent will abort and post a comment explaining why. Apply `autonomous-review` instead to have the agent check the existing PR against the issue requirements and post its findings.
 
 **Tips for writing good autonomous issues:**
 - Be specific about the expected behaviour, not just the goal


### PR DESCRIPTION
Closes #69

## Summary

The GitHub label `autonomous` was already renamed to `autonomous-tdd` directly via the API (no code change needed for that part). The rename carried forward automatically to all issues that had the label applied: #58, #46, #24, #21.

This PR updates the code/docs references that hardcoded the old label name as a string so they match:

- `.github/workflows/opencode-implement.yml` — trigger condition `github.event.label.name == 'autonomous'` → `'autonomous-tdd'`
- `CLAUDE.md` — label description and abort-behaviour text
- `README.md` — contributor-facing instructions for applying the label

`opencode-review.yml`'s `autonomous-review` label/condition is unrelated and untouched.

## Test plan

- [ ] Confirm the `opencode-implement.yml` workflow fires on the `autonomous-tdd` label (e.g. by applying it to a test issue) once merged