### PR TITLE
Add bin/ to .gitignore to prevent Doppler CLI binary from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ data/labels/
 
 # Claude Code session state (ephemeral, not for version control)
 .claude/tdd-state.json
+
+# CI tool binaries (e.g. Doppler CLI installed by dopplerhq/cli-action)
+bin/


### PR DESCRIPTION
Closes #74

## Summary

dopplerhq/cli-action@v4 installs the Doppler CLI binary into $GITHUB_WORKSPACE/bin — inside the git-tracked working directory, not a runner tool-cache path. .gitignore had no bin/ entry, so git status --porcelain saw bin/doppler as untracked, and the opencode wrapper's branchIsDirty() check treated it identically to a real code change. pushToNewBranch() then runs git add . unconditionally before committing, so the binary got staged and committed alongside (or, as in PR #73, instead of) whatever the agent actually changed.

This is a latent defect present in both opencode-implement.yml and opencode-fast.yml equally — both install Doppler via the same action step.

Verified via `git log --all --diff-filter=A --name-only -- 'bin/*'` and `git log main --diff-filter=A --name-only -- 'bin/*'` (both empty): the binary never reached main's history. It only ever existed on the branch backing PR #73, which has since been closed and had its branch deleted. No history cleanup needed on main — this is a forward-looking fix.

## Fix

Add bin/ to .gitignore.